### PR TITLE
fix: disable unused PBR plugin in 2D runtime

### DIFF
--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -183,10 +183,6 @@ fn default_engine_plugins(initial_window: Window) -> PluginGroupBuilder {
         .disable::<bevy::pbr::PbrPlugin>()
 }
 
-fn add_engine_plugins(app: &mut App, initial_window: Window) {
-    app.add_plugins(default_engine_plugins(initial_window));
-}
-
 fn main() {
     install_crash_handler();
 
@@ -222,7 +218,7 @@ fn main() {
         w
     };
 
-    add_engine_plugins(&mut app, initial_window);
+    app.add_plugins(default_engine_plugins(initial_window));
 
     // Parse CLI flags
     if std::env::args().any(|a| a == "--autostart") {

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -7,7 +7,7 @@
     clippy::collapsible_if
 )]
 
-use bevy::prelude::*;
+use bevy::{app::PluginGroupBuilder, prelude::*};
 
 const SURFACE_CRASH_MARKERS: &[&str] = &[
     "Surface is not configured for presentation",
@@ -166,6 +166,27 @@ fn install_crash_handler() {
     }));
 }
 
+fn default_engine_plugins(initial_window: Window) -> PluginGroupBuilder {
+    DefaultPlugins
+        // Endless is a 2D renderer. Disabling Bevy's PBR plugin avoids unused
+        // 3D SSR setup that has been crashing the visible frame.
+        .set(WindowPlugin {
+            primary_window: Some(initial_window),
+            ..default()
+        })
+        .set(bevy::log::LogPlugin {
+            custom_layer: |_app: &mut App| {
+                Some(Box::new(endless::tracing_layer::SystemTimingLayer))
+            },
+            ..default()
+        })
+        .disable::<bevy::pbr::PbrPlugin>()
+}
+
+fn add_engine_plugins(app: &mut App, initial_window: Window) {
+    app.add_plugins(default_engine_plugins(initial_window));
+}
+
 fn main() {
     install_crash_handler();
 
@@ -201,19 +222,7 @@ fn main() {
         w
     };
 
-    app.add_plugins(
-        DefaultPlugins
-            .set(WindowPlugin {
-                primary_window: Some(initial_window),
-                ..default()
-            })
-            .set(bevy::log::LogPlugin {
-                custom_layer: |_app: &mut App| {
-                    Some(Box::new(endless::tracing_layer::SystemTimingLayer))
-                },
-                ..default()
-            }),
-    );
+    add_engine_plugins(&mut app, initial_window);
 
     // Parse CLI flags
     if std::env::args().any(|a| a == "--autostart") {
@@ -249,4 +258,16 @@ fn main() {
     );
 
     app.run();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn engine_plugins_disable_pbr_for_2d_runtime() {
+        let plugins = default_engine_plugins(Window::default());
+
+        assert!(!plugins.enabled::<bevy::pbr::PbrPlugin>());
+    }
 }


### PR DESCRIPTION
## Summary
- disable Bevy's unused PbrPlugin from the startup plugin group for Endless' 2D runtime
- keep the default plugin setup explicit via a helper so the PBR exclusion is easy to validate
- add a regression test that asserts the startup plugin group leaves PBR disabled

## Testing
- cargo test tests::engine_plugins_disable_pbr_for_2d_runtime -- --exact
- cargo test
- cargo build --release --bin endless

Closes #41