### PR TITLE
perf: remove unused deps, trim feature flags

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -685,7 +685,6 @@ dependencies = [
  "bevy_log",
  "bevy_math",
  "bevy_mesh",
- "bevy_picking",
  "bevy_platform",
  "bevy_reflect",
  "bevy_render",
@@ -1061,30 +1060,6 @@ dependencies = [
  "static_assertions",
  "thiserror 2.0.18",
  "tracing",
-]
-
-[[package]]
-name = "bevy_picking"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4d10bb2a776087e1d8a9b87e8deb091d25bcedbe6160c613df2dc5fe069c3c5"
-dependencies = [
- "bevy_app",
- "bevy_asset",
- "bevy_camera",
- "bevy_derive",
- "bevy_ecs",
- "bevy_input",
- "bevy_math",
- "bevy_mesh",
- "bevy_platform",
- "bevy_reflect",
- "bevy_time",
- "bevy_transform",
- "bevy_window",
- "crossbeam-channel",
- "tracing",
- "uuid",
 ]
 
 [[package]]
@@ -2401,12 +2376,10 @@ dependencies = [
  "bevy_framepace",
  "bytemuck",
  "criterion",
- "crossbeam-channel",
  "hashbrown 0.15.5",
  "noise",
  "pathfinding",
  "rand 0.9.2",
- "regex",
  "serde",
  "serde_json",
  "serde_toon2",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -50,21 +50,21 @@ bevy = { version = "0.18", default-features = false, features = [
     "bevy_remote",
     "trace",
 ] }
-bevy_egui = "0.39"
+bevy_egui = { version = "0.39", default-features = false, features = [
+    "manage_clipboard", "open_url", "default_fonts", "render", "bevy_ui",
+] }
 bytemuck = { version = "1", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-crossbeam-channel = "0.5"
 wgpu = { version = "27", default-features = false }
 rand = "0.9"
 noise = "0.9"
 arboard = "3"
 bevy_embedded_assets = "0.15"
-bevy_framepace = "0.21"
+bevy_framepace = { version = "0.21", default-features = false }
 tracing = "0.1"
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"] }
 pathfinding = "4"
-regex = "1.12.3"
 serde_toon2 = "0.1"
 hashbrown = "0.15"
 


### PR DESCRIPTION
## Summary
- Remove `crossbeam-channel` (zero imports)
- Remove `regex` (zero imports)
- `bevy_egui`: `default-features = false` -- drops `bevy_picking` transitive dep
- `tracing-subscriber`: `default-features = false, features = ["registry", "std"]`
- `bevy_framepace`: `default-features = false` -- drops `framepace_debug`
- Remove stale `.disable::<bevy::pbr::PbrPlugin>()` and its test (PBR excluded at feature level by #43)

## Test plan
- [x] cargo clippy --release -- -D warnings clean
- [x] cargo test --no-run compiles
- [ ] cargo run --release: game starts and renders normally

Closes #49

Generated with [Claude Code](https://claude.com/claude-code)