### PR TITLE
move loot carry limit from policy to per-squad UI

### DIFF
--- a/rust/src/resources.rs
+++ b/rust/src/resources.rs
@@ -1736,7 +1736,7 @@ pub struct PolicySet {
     pub loot_threshold: usize,
 }
 
-pub const DEFAULT_LOOT_THRESHOLD: usize = 3;
+pub const DEFAULT_LOOT_THRESHOLD: usize = 1;
 pub const MAX_LOOT_THRESHOLD: usize = 20;
 
 pub(crate) const fn default_loot_threshold() -> usize {
@@ -1761,7 +1761,7 @@ impl Default for PolicySet {
             mining_radius: crate::constants::DEFAULT_MINING_RADIUS,
             reserve_food: 0,
             reserve_gold: 0,
-            loot_threshold: 3,
+            loot_threshold: 1,
         }
     }
 }

--- a/rust/src/systems/decision/mod.rs
+++ b/rust/src/systems/decision/mod.rs
@@ -177,16 +177,11 @@ fn has_rest_destination(home_valid: bool, town_center: Option<Vec2>) -> bool {
 }
 
 #[inline]
-fn loot_threshold_for_npc(
-    squad_state: &SquadState,
-    squad_id: Option<i32>,
-    town_policy: Option<crate::resources::PolicySet>,
-) -> usize {
+fn loot_threshold_for_npc(squad_state: &SquadState, squad_id: Option<i32>) -> usize {
     squad_id
         .and_then(|sid| usize::try_from(sid).ok())
         .and_then(|sid| squad_state.squads.get(sid))
         .map(|squad| squad.loot_threshold)
-        .or_else(|| town_policy.map(|policy| policy.loot_threshold))
         .unwrap_or(DEFAULT_LOOT_THRESHOLD)
 }
 
@@ -1722,8 +1717,7 @@ pub fn decision_system(
             // ====================================================================
             // Priority 4c: Loot threshold — too much equipment, return home
             // ====================================================================
-            let loot_threshold =
-                loot_threshold_for_npc(squad_state, squad_id, economy.towns.policy(town_idx_i32));
+            let loot_threshold = loot_threshold_for_npc(squad_state, squad_id);
             if !npc_def(job).equip_slots.is_empty()
                 && carried_loot.equipment.len() >= loot_threshold
                 && activity.kind != ActivityKind::ReturnLoot

--- a/rust/src/systems/decision/tests.rs
+++ b/rust/src/systems/decision/tests.rs
@@ -100,11 +100,10 @@ fn test_carried_loot(count: usize) -> CarriedLoot {
     }
 }
 #[test]
-fn squad_loot_threshold_overrides_town_policy() {
+fn squad_loot_threshold_controls_return() {
     DECISION_FRAME.store(0, std::sync::atomic::Ordering::Relaxed);
 
-    let mut policy = PolicySet::default();
-    policy.loot_threshold = 1;
+    let policy = PolicySet::default();
     let mut app = setup_decision_app(policy);
     app.world_mut().resource_mut::<SquadState>().squads[0].loot_threshold = 3;
 
@@ -139,17 +138,17 @@ fn squad_loot_threshold_overrides_town_policy() {
     assert_ne!(
         activity.kind,
         ActivityKind::ReturnLoot,
-        "squad threshold should block the lower town-wide fallback"
+        "squad threshold of 3 should prevent return when carrying only 2 items"
     );
 }
 
 #[test]
-fn town_loot_threshold_applies_without_squad() {
-    let mut policy = PolicySet::default();
-    policy.loot_threshold = 2;
+fn no_squad_uses_default_loot_threshold() {
     let squad_state = SquadState::default();
-
-    assert_eq!(loot_threshold_for_npc(&squad_state, None, Some(policy)), 2);
+    assert_eq!(
+        loot_threshold_for_npc(&squad_state, None),
+        DEFAULT_LOOT_THRESHOLD
+    );
 }
 // ========================================================================
 // transition helper tests -- verify kind + phase + target invariants

--- a/rust/src/systems/llm_player.rs
+++ b/rust/src/systems/llm_player.rs
@@ -661,7 +661,6 @@ fn execute_actions(
                                     policy.0.mining_radius = v.clamp(0.0, 5000.0);
                                 }
                             }
-                            // loot_threshold removed from policy -- now per-squad only (issue #60)
                             _ => {}
                         }
                     }

--- a/rust/src/systems/llm_player.rs
+++ b/rust/src/systems/llm_player.rs
@@ -661,12 +661,7 @@ fn execute_actions(
                                     policy.0.mining_radius = v.clamp(0.0, 5000.0);
                                 }
                             }
-                            "loot_threshold" => {
-                                if let Ok(v) = val.parse::<usize>() {
-                                    policy.0.loot_threshold =
-                                        v.clamp(1, crate::resources::MAX_LOOT_THRESHOLD);
-                                }
-                            }
+                            // loot_threshold removed from policy -- now per-squad only (issue #60)
                             _ => {}
                         }
                     }

--- a/rust/src/systems/remote.rs
+++ b/rust/src/systems/remote.rs
@@ -560,8 +560,7 @@ struct PolicyParams {
     recovery_hp: Option<f32>,
     #[serde(default)]
     mining_radius: Option<f32>,
-    #[serde(default)]
-    loot_threshold: Option<usize>,
+    // loot_threshold removed -- now per-squad only (issue #60)
 }
 
 pub fn policy_handler(In(params): In<Option<Value>>, world: &mut World) -> BrpResult {
@@ -640,13 +639,7 @@ pub fn policy_handler(In(params): In<Option<Value>>, world: &mut World) -> BrpRe
             }
             policy.mining_radius = v;
         }
-        if let Some(v) = p.loot_threshold {
-            let v = v.clamp(1, crate::resources::MAX_LOOT_THRESHOLD);
-            if v != policy.loot_threshold {
-                parts.push(format!("loot_threshold={v}"));
-            }
-            policy.loot_threshold = v;
-        }
+        // loot_threshold removed from policy -- now per-squad only (see issue #60)
         parts
     };
     if !parts.is_empty() {

--- a/rust/src/systems/remote.rs
+++ b/rust/src/systems/remote.rs
@@ -560,7 +560,6 @@ struct PolicyParams {
     recovery_hp: Option<f32>,
     #[serde(default)]
     mining_radius: Option<f32>,
-    // loot_threshold removed -- now per-squad only (issue #60)
 }
 
 pub fn policy_handler(In(params): In<Option<Value>>, world: &mut World) -> BrpResult {
@@ -639,7 +638,6 @@ pub fn policy_handler(In(params): In<Option<Value>>, world: &mut World) -> BrpRe
             }
             policy.mining_radius = v;
         }
-        // loot_threshold removed from policy -- now per-squad only (see issue #60)
         parts
     };
     if !parts.is_empty() {

--- a/rust/src/ui/left_panel/mod.rs
+++ b/rust/src/ui/left_panel/mod.rs
@@ -805,17 +805,6 @@ fn policies_content(
             policy.reserve_gold = rg;
         }
     });
-
-    // -- Loot --
-    ui.add_space(8.0);
-    ui.label(egui::RichText::new("Loot").strong());
-    let mut lt = policy.loot_threshold;
-    ui.horizontal(|ui| {
-        ui.label("Carry limit:");
-        ui.add(egui::Slider::new(&mut lt, 1..=20).suffix(" items"));
-    });
-    policy.loot_threshold = lt;
-    ui.small("Equipment items carried before NPC returns home");
 }
 
 // ============================================================================
@@ -995,6 +984,18 @@ fn squads_content(
     {
         squad.squad_state.squads[si].hold_fire = hold_fire;
     }
+    ui.add_space(4.0);
+    ui.horizontal(|ui| {
+        ui.label("Carry limit:");
+        let mut lt = squad.squad_state.squads[si].loot_threshold;
+        if ui
+            .add(egui::Slider::new(&mut lt, 1..=20).suffix(" items"))
+            .changed()
+        {
+            squad.squad_state.squads[si].loot_threshold = lt;
+        }
+    });
+    ui.small("Equipment items carried before NPC returns home");
 
     ui.add_space(4.0);
 


### PR DESCRIPTION
## Summary
- Remove loot carry limit slider from Policy tab
- Add per-squad carry limit slider to Squads tab
- Simplify decision_system to read threshold from squad only (no policy fallback)
- Change default threshold from 3 to 1

Closes #60

## Test plan
- [x] cargo check
- [x] cargo fmt
- [x] cargo clippy --release -- -D warnings
- [ ] cargo test (275 passed)
- [ ] in-game: squad tab shows slider, policy tab does not