### PR TITLE
fix: resource icon order and missing food/gold icons

### DIFF
--- a/rust/src/ui/game_hud.rs
+++ b/rust/src/ui/game_hud.rs
@@ -82,13 +82,70 @@ fn npc_link(
     None
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ResourceIconAtlas {
+    World,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum HudResourceIcon {
+    Food,
+    Gold,
+    Wood,
+    Stone,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct ResourceIconSpec {
+    atlas: ResourceIconAtlas,
+    col: u32,
+    row: u32,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ResourceIconContentOrder {
+    IconThenValue,
+}
+
+fn resource_icon_spec(icon: HudResourceIcon) -> ResourceIconSpec {
+    match icon {
+        HudResourceIcon::Food => ResourceIconSpec {
+            atlas: ResourceIconAtlas::World,
+            col: 24,
+            row: 9,
+        },
+        HudResourceIcon::Gold => ResourceIconSpec {
+            atlas: ResourceIconAtlas::World,
+            col: 41,
+            row: 11,
+        },
+        HudResourceIcon::Wood => ResourceIconSpec {
+            atlas: ResourceIconAtlas::World,
+            col: 13,
+            row: 9,
+        },
+        HudResourceIcon::Stone => ResourceIconSpec {
+            atlas: ResourceIconAtlas::World,
+            col: 7,
+            row: 15,
+        },
+    }
+}
+
+fn resource_icon_content_order() -> ResourceIconContentOrder {
+    ResourceIconContentOrder::IconThenValue
+}
+
+fn resource_icon_uv(icon: HudResourceIcon, atlas_w: u32, atlas_h: u32) -> egui::Rect {
+    let spec = resource_icon_spec(icon);
+    cell_uv(spec.col, spec.row, atlas_w, atlas_h)
+}
+
 /// Cached egui texture IDs + UV rects for resource icons from atlas spritesheets.
 #[derive(Resource, Default)]
 pub struct ResourceIconCache {
     pub initialized: bool,
-    pub char_tex: Option<egui::TextureId>,
     pub world_tex: Option<egui::TextureId>,
-    /// (texture_id field name, uv rect) per resource
     pub food_uv: Option<egui::Rect>,
     pub gold_uv: Option<egui::Rect>,
     pub wood_uv: Option<egui::Rect>,
@@ -114,19 +171,7 @@ pub fn init_resource_icons(
     sprites: Res<crate::render::SpriteAssets>,
     images: Res<Assets<Image>>,
 ) {
-    // Register char atlas (food + gold)
-    if cache.char_tex.is_none() {
-        if let Some(a) = images.get(&sprites.char_texture) {
-            let tex = contexts.add_image(bevy_egui::EguiTextureHandle::Weak(
-                sprites.char_texture.id(),
-            ));
-            let (w, h) = (a.width(), a.height());
-            cache.char_tex = Some(tex);
-            cache.food_uv = Some(cell_uv(24, 9, w, h));
-            cache.gold_uv = Some(cell_uv(41, 11, w, h));
-        }
-    }
-    // Register world atlas (wood + stone)
+    // All four HUD resources live on the world atlas, not the character atlas.
     if cache.world_tex.is_none() {
         if let Some(a) = images.get(&sprites.world_texture) {
             let tex = contexts.add_image(bevy_egui::EguiTextureHandle::Weak(
@@ -134,11 +179,17 @@ pub fn init_resource_icons(
             ));
             let (w, h) = (a.width(), a.height());
             cache.world_tex = Some(tex);
-            cache.wood_uv = Some(cell_uv(13, 9, w, h));
-            cache.stone_uv = Some(cell_uv(7, 15, w, h));
+            cache.food_uv = Some(resource_icon_uv(HudResourceIcon::Food, w, h));
+            cache.gold_uv = Some(resource_icon_uv(HudResourceIcon::Gold, w, h));
+            cache.wood_uv = Some(resource_icon_uv(HudResourceIcon::Wood, w, h));
+            cache.stone_uv = Some(resource_icon_uv(HudResourceIcon::Stone, w, h));
         }
     }
-    cache.initialized = cache.char_tex.is_some() && cache.world_tex.is_some();
+    cache.initialized = cache.world_tex.is_some()
+        && cache.food_uv.is_some()
+        && cache.gold_uv.is_some()
+        && cache.wood_uv.is_some()
+        && cache.stone_uv.is_some();
 }
 
 /// Render a resource sprite icon + amount with tooltip.
@@ -153,24 +204,28 @@ fn resource_icon(
 ) {
     let icon_size = 16.0;
     let spacing = 2.0;
-    // RTL parent reverses child order, so we render value then icon
-    // which visually becomes icon:value
-    ui.horizontal(|ui| {
+    ui.with_layout(egui::Layout::left_to_right(egui::Align::Center), |ui| {
         ui.spacing_mut().item_spacing.x = spacing;
-        ui.label(egui::RichText::new(amount.to_string()).color(color));
-        if let (Some(tex_id), Some(uv_rect)) = (atlas_tex, uv) {
-            ui.add(
-                egui::Image::new(egui::load::SizedTexture::new(
-                    tex_id,
-                    [icon_size, icon_size],
-                ))
-                .uv(uv_rect)
-                .tint(egui::Color32::WHITE),
-            );
-        } else {
-            let (rect, _) =
-                ui.allocate_exact_size(egui::vec2(icon_size, icon_size), egui::Sense::hover());
-            ui.painter().rect_filled(rect, 2.0, color);
+        match resource_icon_content_order() {
+            ResourceIconContentOrder::IconThenValue => {
+                if let (Some(tex_id), Some(uv_rect)) = (atlas_tex, uv) {
+                    ui.add(
+                        egui::Image::new(egui::load::SizedTexture::new(
+                            tex_id,
+                            [icon_size, icon_size],
+                        ))
+                        .uv(uv_rect)
+                        .tint(egui::Color32::WHITE),
+                    );
+                } else {
+                    let (rect, _) = ui.allocate_exact_size(
+                        egui::vec2(icon_size, icon_size),
+                        egui::Sense::hover(),
+                    );
+                    ui.painter().rect_filled(rect, 2.0, color);
+                }
+                ui.label(egui::RichText::new(amount.to_string()).color(color));
+            }
         }
     })
     .response
@@ -486,7 +541,7 @@ pub fn top_bar_system(
                     resource_icon(
                         ui,
                         town_food,
-                        icon_cache.char_tex,
+                        icon_cache.world_tex,
                         icon_cache.food_uv,
                         egui::Color32::from_rgb(120, 200, 80),
                         catalog.0.get("food").unwrap_or(&""),
@@ -494,7 +549,7 @@ pub fn top_bar_system(
                     resource_icon(
                         ui,
                         town_gold,
-                        icon_cache.char_tex,
+                        icon_cache.world_tex,
                         icon_cache.gold_uv,
                         egui::Color32::from_rgb(220, 190, 50),
                         catalog.0.get("gold").unwrap_or(&""),
@@ -3530,4 +3585,53 @@ pub fn save_toast_system(mut contexts: EguiContexts, toast: Res<crate::save::Sav
         });
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resource_icon_specs_use_world_atlas_cells() {
+        assert_eq!(
+            resource_icon_spec(HudResourceIcon::Food),
+            ResourceIconSpec {
+                atlas: ResourceIconAtlas::World,
+                col: 24,
+                row: 9,
+            }
+        );
+        assert_eq!(
+            resource_icon_spec(HudResourceIcon::Gold),
+            ResourceIconSpec {
+                atlas: ResourceIconAtlas::World,
+                col: 41,
+                row: 11,
+            }
+        );
+        assert_eq!(
+            resource_icon_spec(HudResourceIcon::Wood),
+            ResourceIconSpec {
+                atlas: ResourceIconAtlas::World,
+                col: 13,
+                row: 9,
+            }
+        );
+        assert_eq!(
+            resource_icon_spec(HudResourceIcon::Stone),
+            ResourceIconSpec {
+                atlas: ResourceIconAtlas::World,
+                col: 7,
+                row: 15,
+            }
+        );
+    }
+
+    #[test]
+    fn resource_icons_render_icon_before_value() {
+        assert_eq!(
+            resource_icon_content_order(),
+            ResourceIconContentOrder::IconThenValue
+        );
+    }
 }

--- a/rust/src/ui/game_hud.rs
+++ b/rust/src/ui/game_hud.rs
@@ -102,11 +102,6 @@ struct ResourceIconSpec {
     row: u32,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum ResourceIconContentOrder {
-    IconThenValue,
-}
-
 fn resource_icon_spec(icon: HudResourceIcon) -> ResourceIconSpec {
     match icon {
         HudResourceIcon::Food => ResourceIconSpec {
@@ -132,13 +127,23 @@ fn resource_icon_spec(icon: HudResourceIcon) -> ResourceIconSpec {
     }
 }
 
-fn resource_icon_content_order() -> ResourceIconContentOrder {
-    ResourceIconContentOrder::IconThenValue
-}
-
 fn resource_icon_uv(icon: HudResourceIcon, atlas_w: u32, atlas_h: u32) -> egui::Rect {
     let spec = resource_icon_spec(icon);
     cell_uv(spec.col, spec.row, atlas_w, atlas_h)
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ResourceIconPart {
+    Icon,
+    Value,
+}
+
+fn resource_icon_parts(prefer_right_to_left: bool) -> [ResourceIconPart; 2] {
+    if prefer_right_to_left {
+        [ResourceIconPart::Value, ResourceIconPart::Icon]
+    } else {
+        [ResourceIconPart::Icon, ResourceIconPart::Value]
+    }
 }
 
 /// Cached egui texture IDs + UV rects for resource icons from atlas spritesheets.
@@ -204,27 +209,32 @@ fn resource_icon(
 ) {
     let icon_size = 16.0;
     let spacing = 2.0;
-    ui.with_layout(egui::Layout::left_to_right(egui::Align::Center), |ui| {
+    let parts = resource_icon_parts(ui.layout().prefer_right_to_left());
+    ui.horizontal(|ui| {
         ui.spacing_mut().item_spacing.x = spacing;
-        match resource_icon_content_order() {
-            ResourceIconContentOrder::IconThenValue => {
-                if let (Some(tex_id), Some(uv_rect)) = (atlas_tex, uv) {
-                    ui.add(
-                        egui::Image::new(egui::load::SizedTexture::new(
-                            tex_id,
-                            [icon_size, icon_size],
-                        ))
-                        .uv(uv_rect)
-                        .tint(egui::Color32::WHITE),
-                    );
-                } else {
-                    let (rect, _) = ui.allocate_exact_size(
-                        egui::vec2(icon_size, icon_size),
-                        egui::Sense::hover(),
-                    );
-                    ui.painter().rect_filled(rect, 2.0, color);
+        for part in parts {
+            match part {
+                ResourceIconPart::Icon => {
+                    if let (Some(tex_id), Some(uv_rect)) = (atlas_tex, uv) {
+                        ui.add(
+                            egui::Image::new(egui::load::SizedTexture::new(
+                                tex_id,
+                                [icon_size, icon_size],
+                            ))
+                            .uv(uv_rect)
+                            .tint(egui::Color32::WHITE),
+                        );
+                    } else {
+                        let (rect, _) = ui.allocate_exact_size(
+                            egui::vec2(icon_size, icon_size),
+                            egui::Sense::hover(),
+                        );
+                        ui.painter().rect_filled(rect, 2.0, color);
+                    }
                 }
-                ui.label(egui::RichText::new(amount.to_string()).color(color));
+                ResourceIconPart::Value => {
+                    ui.label(egui::RichText::new(amount.to_string()).color(color));
+                }
             }
         }
     })
@@ -3628,10 +3638,14 @@ mod tests {
     }
 
     #[test]
-    fn resource_icons_render_icon_before_value() {
+    fn resource_icon_parts_flip_for_rtl_parents() {
         assert_eq!(
-            resource_icon_content_order(),
-            ResourceIconContentOrder::IconThenValue
+            resource_icon_parts(false),
+            [ResourceIconPart::Icon, ResourceIconPart::Value]
+        );
+        assert_eq!(
+            resource_icon_parts(true),
+            [ResourceIconPart::Value, ResourceIconPart::Icon]
         );
     }
 }

--- a/rust/src/ui/game_hud.rs
+++ b/rust/src/ui/game_hud.rs
@@ -82,136 +82,96 @@ fn npc_link(
     None
 }
 
-/// Cached egui texture IDs for resource icons. Initialized once from atlas sprites.
+/// Cached egui texture IDs + UV rects for resource icons from atlas spritesheets.
 #[derive(Resource, Default)]
 pub struct ResourceIconCache {
     pub initialized: bool,
-    pub food: Option<egui::TextureId>,
-    pub gold: Option<egui::TextureId>,
-    pub wood: Option<egui::TextureId>,
-    pub stone: Option<egui::TextureId>,
-    _handles: Vec<Handle<Image>>,
+    pub char_tex: Option<egui::TextureId>,
+    pub world_tex: Option<egui::TextureId>,
+    /// (texture_id field name, uv rect) per resource
+    pub food_uv: Option<egui::Rect>,
+    pub gold_uv: Option<egui::Rect>,
+    pub wood_uv: Option<egui::Rect>,
+    pub stone_uv: Option<egui::Rect>,
 }
 
-/// Extract a single 16x16 sprite from a 17px-cell atlas at (col, row).
-fn extract_atlas_cell(atlas: &Image, col: u32, row: u32, cell_size: u32) -> Option<Image> {
-    let sprite_size = cell_size - 1; // 16px sprite in 17px cell
-    let src_w = atlas.width();
-    let src_data = atlas.data.as_ref()?;
-    let px = col * cell_size;
-    let py = row * cell_size;
-    let mut data = vec![0u8; (sprite_size * sprite_size * 4) as usize];
-    for y in 0..sprite_size {
-        for x in 0..sprite_size {
-            let sx = (px + x) as usize;
-            let sy = (py + y) as usize;
-            let src_idx = (sy * src_w as usize + sx) * 4;
-            let dst_idx = (y * sprite_size + x) as usize * 4;
-            if src_idx + 3 < src_data.len() {
-                data[dst_idx..dst_idx + 4].copy_from_slice(&src_data[src_idx..src_idx + 4]);
-            }
-        }
-    }
-    Some(Image::new(
-        bevy::render::render_resource::Extent3d {
-            width: sprite_size,
-            height: sprite_size,
-            depth_or_array_layers: 1,
-        },
-        bevy::render::render_resource::TextureDimension::D2,
-        data,
-        bevy::render::render_resource::TextureFormat::Rgba8UnormSrgb,
-        Default::default(),
-    ))
+/// Compute UV rect for a cell in a 17px-cell atlas.
+fn cell_uv(col: u32, row: u32, atlas_w: u32, atlas_h: u32) -> egui::Rect {
+    let cell = 17.0;
+    let sprite = 16.0;
+    let x = col as f32 * cell;
+    let y = row as f32 * cell;
+    egui::Rect::from_min_max(
+        egui::pos2(x / atlas_w as f32, y / atlas_h as f32),
+        egui::pos2((x + sprite) / atlas_w as f32, (y + sprite) / atlas_h as f32),
+    )
 }
 
-/// Initialize resource icon textures from atlas sprites. Runs until all 4 icons load.
+/// Register atlas textures with egui and compute UV rects for each resource icon.
 pub fn init_resource_icons(
     mut cache: ResMut<ResourceIconCache>,
     mut contexts: EguiContexts,
     sprites: Res<crate::render::SpriteAssets>,
-    mut images: ResMut<Assets<Image>>,
+    images: Res<Assets<Image>>,
 ) {
-    let cell = 17u32;
-
-    // Extract cells while borrowing atlases (no clone), collect to release borrows before add
-    let mut pending: Vec<(&str, Image)> = Vec::new();
-    if cache.food.is_none() {
+    // Register char atlas (food + gold)
+    if cache.char_tex.is_none() {
         if let Some(a) = images.get(&sprites.char_texture) {
-            if let Some(img) = extract_atlas_cell(a, 24, 9, cell) {
-                pending.push(("food", img));
-            }
+            let tex = contexts.add_image(bevy_egui::EguiTextureHandle::Weak(
+                sprites.char_texture.id(),
+            ));
+            let (w, h) = (a.width(), a.height());
+            cache.char_tex = Some(tex);
+            cache.food_uv = Some(cell_uv(24, 9, w, h));
+            cache.gold_uv = Some(cell_uv(41, 11, w, h));
         }
     }
-    if cache.gold.is_none() {
-        if let Some(a) = images.get(&sprites.char_texture) {
-            if let Some(img) = extract_atlas_cell(a, 41, 11, cell) {
-                pending.push(("gold", img));
-            }
-        }
-    }
-    if cache.wood.is_none() {
+    // Register world atlas (wood + stone)
+    if cache.world_tex.is_none() {
         if let Some(a) = images.get(&sprites.world_texture) {
-            if let Some(img) = extract_atlas_cell(a, 13, 9, cell) {
-                pending.push(("wood", img));
-            }
+            let tex = contexts.add_image(bevy_egui::EguiTextureHandle::Weak(
+                sprites.world_texture.id(),
+            ));
+            let (w, h) = (a.width(), a.height());
+            cache.world_tex = Some(tex);
+            cache.wood_uv = Some(cell_uv(13, 9, w, h));
+            cache.stone_uv = Some(cell_uv(7, 15, w, h));
         }
     }
-    if cache.stone.is_none() {
-        if let Some(a) = images.get(&sprites.world_texture) {
-            if let Some(img) = extract_atlas_cell(a, 7, 15, cell) {
-                pending.push(("stone", img));
-            }
-        }
-    }
-
-    for (name, img) in pending {
-        let h = images.add(img);
-        let tex = contexts.add_image(bevy_egui::EguiTextureHandle::Strong(h.clone()));
-        match name {
-            "food" => cache.food = Some(tex),
-            "gold" => cache.gold = Some(tex),
-            "wood" => cache.wood = Some(tex),
-            "stone" => cache.stone = Some(tex),
-            _ => {}
-        }
-        cache._handles.push(h);
-    }
-
-    cache.initialized = cache.food.is_some()
-        && cache.gold.is_some()
-        && cache.wood.is_some()
-        && cache.stone.is_some();
+    cache.initialized = cache.char_tex.is_some() && cache.world_tex.is_some();
 }
 
 /// Render a resource sprite icon + amount with tooltip.
+/// Uses atlas texture + UV rect for the icon, falls back to colored square.
 fn resource_icon(
     ui: &mut egui::Ui,
     amount: i32,
-    tex: Option<egui::TextureId>,
+    atlas_tex: Option<egui::TextureId>,
+    uv: Option<egui::Rect>,
     color: egui::Color32,
     tip: &str,
 ) {
     let icon_size = 16.0;
     let spacing = 2.0;
-    // Force left-to-right so icon:value order is correct even inside RTL parent
-    ui.with_layout(egui::Layout::left_to_right(egui::Align::Center), |ui| {
+    // RTL parent reverses child order, so we render value then icon
+    // which visually becomes icon:value
+    ui.horizontal(|ui| {
         ui.spacing_mut().item_spacing.x = spacing;
-        if let Some(tex_id) = tex {
+        ui.label(egui::RichText::new(amount.to_string()).color(color));
+        if let (Some(tex_id), Some(uv_rect)) = (atlas_tex, uv) {
             ui.add(
                 egui::Image::new(egui::load::SizedTexture::new(
                     tex_id,
                     [icon_size, icon_size],
                 ))
+                .uv(uv_rect)
                 .tint(egui::Color32::WHITE),
             );
         } else {
-            // Fallback: colored square if textures not loaded yet
             let (rect, _) =
                 ui.allocate_exact_size(egui::vec2(icon_size, icon_size), egui::Sense::hover());
             ui.painter().rect_filled(rect, 2.0, color);
         }
-        ui.label(egui::RichText::new(amount.to_string()).color(color));
     })
     .response
     .on_hover_text(tip);
@@ -510,28 +470,32 @@ pub fn top_bar_system(
                     resource_icon(
                         ui,
                         town_wood,
-                        icon_cache.wood,
+                        icon_cache.world_tex,
+                        icon_cache.wood_uv,
                         egui::Color32::from_rgb(150, 110, 70),
                         catalog.0.get("wood").unwrap_or(&""),
                     );
                     resource_icon(
                         ui,
                         town_stone,
-                        icon_cache.stone,
+                        icon_cache.world_tex,
+                        icon_cache.stone_uv,
                         egui::Color32::from_rgb(170, 170, 180),
                         catalog.0.get("stone").unwrap_or(&""),
                     );
                     resource_icon(
                         ui,
                         town_food,
-                        icon_cache.food,
+                        icon_cache.char_tex,
+                        icon_cache.food_uv,
                         egui::Color32::from_rgb(120, 200, 80),
                         catalog.0.get("food").unwrap_or(&""),
                     );
                     resource_icon(
                         ui,
                         town_gold,
-                        icon_cache.gold,
+                        icon_cache.char_tex,
+                        icon_cache.gold_uv,
                         egui::Color32::from_rgb(220, 190, 50),
                         catalog.0.get("gold").unwrap_or(&""),
                     );

--- a/rust/src/ui/game_hud.rs
+++ b/rust/src/ui/game_hud.rs
@@ -141,6 +141,24 @@ fn resource_icon_parts(prefer_right_to_left: bool) -> [ResourceIconPart; 2] {
     }
 }
 
+fn top_bar_resource_display_order() -> [HudResourceIcon; 4] {
+    [
+        HudResourceIcon::Wood,
+        HudResourceIcon::Stone,
+        HudResourceIcon::Food,
+        HudResourceIcon::Gold,
+    ]
+}
+
+fn top_bar_resource_widget_order(prefer_right_to_left: bool) -> [HudResourceIcon; 4] {
+    let [a, b, c, d] = top_bar_resource_display_order();
+    if prefer_right_to_left {
+        [d, c, b, a]
+    } else {
+        [a, b, c, d]
+    }
+}
+
 /// Cached egui texture IDs for resource icons extracted from atlas sprites.
 #[derive(Resource, Default)]
 pub struct ResourceIconCache {
@@ -567,35 +585,38 @@ pub fn top_bar_system(
                     let town_gold = town_access.gold(0);
                     let town_wood = town_access.wood(0);
                     let town_stone = town_access.stone(0);
-
-                    resource_icon(
-                        ui,
-                        town_wood,
-                        icon_cache.wood.as_ref(),
-                        egui::Color32::from_rgb(150, 110, 70),
-                        catalog.0.get("wood").unwrap_or(&""),
-                    );
-                    resource_icon(
-                        ui,
-                        town_stone,
-                        icon_cache.stone.as_ref(),
-                        egui::Color32::from_rgb(170, 170, 180),
-                        catalog.0.get("stone").unwrap_or(&""),
-                    );
-                    resource_icon(
-                        ui,
-                        town_food,
-                        icon_cache.food.as_ref(),
-                        egui::Color32::from_rgb(120, 200, 80),
-                        catalog.0.get("food").unwrap_or(&""),
-                    );
-                    resource_icon(
-                        ui,
-                        town_gold,
-                        icon_cache.gold.as_ref(),
-                        egui::Color32::from_rgb(220, 190, 50),
-                        catalog.0.get("gold").unwrap_or(&""),
-                    );
+                    for icon in top_bar_resource_widget_order(ui.layout().prefer_right_to_left()) {
+                        match icon {
+                            HudResourceIcon::Wood => resource_icon(
+                                ui,
+                                town_wood,
+                                icon_cache.wood.as_ref(),
+                                egui::Color32::from_rgb(150, 110, 70),
+                                catalog.0.get("wood").unwrap_or(&""),
+                            ),
+                            HudResourceIcon::Stone => resource_icon(
+                                ui,
+                                town_stone,
+                                icon_cache.stone.as_ref(),
+                                egui::Color32::from_rgb(170, 170, 180),
+                                catalog.0.get("stone").unwrap_or(&""),
+                            ),
+                            HudResourceIcon::Food => resource_icon(
+                                ui,
+                                town_food,
+                                icon_cache.food.as_ref(),
+                                egui::Color32::from_rgb(120, 200, 80),
+                                catalog.0.get("food").unwrap_or(&""),
+                            ),
+                            HudResourceIcon::Gold => resource_icon(
+                                ui,
+                                town_gold,
+                                icon_cache.gold.as_ref(),
+                                egui::Color32::from_rgb(220, 190, 50),
+                                catalog.0.get("gold").unwrap_or(&""),
+                            ),
+                        }
+                    }
 
                     let farmers = pop_stats.0.get(&(0, 0)).map(|s| s.alive).unwrap_or(0);
                     let guards = pop_stats.0.get(&(1, 0)).map(|s| s.alive).unwrap_or(0);
@@ -3678,6 +3699,37 @@ mod tests {
         assert_eq!(
             resource_icon_parts(true),
             [ResourceIconPart::Value, ResourceIconPart::Icon]
+        );
+    }
+
+    #[test]
+    fn top_bar_resource_order_stays_wood_stone_food_gold_on_screen() {
+        assert_eq!(
+            top_bar_resource_display_order(),
+            [
+                HudResourceIcon::Wood,
+                HudResourceIcon::Stone,
+                HudResourceIcon::Food,
+                HudResourceIcon::Gold,
+            ]
+        );
+        assert_eq!(
+            top_bar_resource_widget_order(false),
+            [
+                HudResourceIcon::Wood,
+                HudResourceIcon::Stone,
+                HudResourceIcon::Food,
+                HudResourceIcon::Gold,
+            ]
+        );
+        assert_eq!(
+            top_bar_resource_widget_order(true),
+            [
+                HudResourceIcon::Gold,
+                HudResourceIcon::Food,
+                HudResourceIcon::Stone,
+                HudResourceIcon::Wood,
+            ]
         );
     }
 

--- a/rust/src/ui/game_hud.rs
+++ b/rust/src/ui/game_hud.rs
@@ -145,14 +145,19 @@ fn resource_icon_parts(prefer_right_to_left: bool) -> [ResourceIconPart; 2] {
 #[derive(Resource, Default)]
 pub struct ResourceIconCache {
     pub initialized: bool,
-    pub food: Option<egui::TextureId>,
-    pub gold: Option<egui::TextureId>,
-    pub wood: Option<egui::TextureId>,
-    pub stone: Option<egui::TextureId>,
+    pub food: Option<egui::TextureHandle>,
+    pub gold: Option<egui::TextureHandle>,
+    pub wood: Option<egui::TextureHandle>,
+    pub stone: Option<egui::TextureHandle>,
 }
 
 /// Extract a single 16x16 sprite from a 17px-cell atlas at (col, row).
-fn extract_atlas_cell(atlas: &Image, col: u32, row: u32, cell_size: u32) -> Option<Image> {
+fn extract_atlas_cell(
+    atlas: &Image,
+    col: u32,
+    row: u32,
+    cell_size: u32,
+) -> Option<egui::ColorImage> {
     let sprite_size = cell_size - 1;
     let src_w = atlas.width();
     let src_data = atlas.data.as_ref()?;
@@ -170,16 +175,9 @@ fn extract_atlas_cell(atlas: &Image, col: u32, row: u32, cell_size: u32) -> Opti
             }
         }
     }
-    Some(Image::new(
-        bevy::render::render_resource::Extent3d {
-            width: sprite_size,
-            height: sprite_size,
-            depth_or_array_layers: 1,
-        },
-        bevy::render::render_resource::TextureDimension::D2,
-        data,
-        bevy::render::render_resource::TextureFormat::Rgba8UnormSrgb,
-        Default::default(),
+    Some(egui::ColorImage::from_rgba_unmultiplied(
+        [sprite_size as usize, sprite_size as usize],
+        &data,
     ))
 }
 
@@ -188,10 +186,13 @@ pub fn init_resource_icons(
     mut cache: ResMut<ResourceIconCache>,
     mut contexts: EguiContexts,
     sprites: Res<crate::render::SpriteAssets>,
-    mut images: ResMut<Assets<Image>>,
+    images: Res<Assets<Image>>,
 ) {
+    let Ok(ctx) = contexts.ctx_mut() else {
+        return;
+    };
     let cell = 17u32;
-    let mut pending: Vec<(HudResourceIcon, Image)> = Vec::new();
+    let mut pending: Vec<(HudResourceIcon, egui::ColorImage)> = Vec::new();
     if let Some(atlas) = images.get(&sprites.world_texture) {
         for icon in [
             HudResourceIcon::Food,
@@ -216,8 +217,11 @@ pub fn init_resource_icons(
         }
     }
     for (icon, img) in pending {
-        let handle = images.add(img);
-        let tex = contexts.add_image(bevy_egui::EguiTextureHandle::Strong(handle));
+        let tex = ctx.load_texture(
+            format!("resource-icon-{icon:?}"),
+            img,
+            egui::TextureOptions::NEAREST,
+        );
         match icon {
             HudResourceIcon::Food => cache.food = Some(tex),
             HudResourceIcon::Gold => cache.gold = Some(tex),
@@ -236,7 +240,7 @@ pub fn init_resource_icons(
 fn resource_icon(
     ui: &mut egui::Ui,
     amount: i32,
-    tex: Option<egui::TextureId>,
+    tex: Option<&egui::TextureHandle>,
     color: egui::Color32,
     tip: &str,
 ) {
@@ -248,10 +252,10 @@ fn resource_icon(
         for part in parts {
             match part {
                 ResourceIconPart::Icon => {
-                    if let Some(tex_id) = tex {
+                    if let Some(tex) = tex {
                         ui.add(
                             egui::Image::new(egui::load::SizedTexture::new(
-                                tex_id,
+                                tex.id(),
                                 [icon_size, icon_size],
                             ))
                             .tint(egui::Color32::WHITE),
@@ -567,28 +571,28 @@ pub fn top_bar_system(
                     resource_icon(
                         ui,
                         town_wood,
-                        icon_cache.wood,
+                        icon_cache.wood.as_ref(),
                         egui::Color32::from_rgb(150, 110, 70),
                         catalog.0.get("wood").unwrap_or(&""),
                     );
                     resource_icon(
                         ui,
                         town_stone,
-                        icon_cache.stone,
+                        icon_cache.stone.as_ref(),
                         egui::Color32::from_rgb(170, 170, 180),
                         catalog.0.get("stone").unwrap_or(&""),
                     );
                     resource_icon(
                         ui,
                         town_food,
-                        icon_cache.food,
+                        icon_cache.food.as_ref(),
                         egui::Color32::from_rgb(120, 200, 80),
                         catalog.0.get("food").unwrap_or(&""),
                     );
                     resource_icon(
                         ui,
                         town_gold,
-                        icon_cache.gold,
+                        icon_cache.gold.as_ref(),
                         egui::Color32::from_rgb(220, 190, 50),
                         catalog.0.get("gold").unwrap_or(&""),
                     );
@@ -3696,8 +3700,8 @@ mod tests {
         );
 
         let icon = extract_atlas_cell(&atlas, 0, 0, cell_size).expect("cell should extract");
-        let pixels = icon.data.as_ref().expect("icon image should contain data");
-        assert_eq!(&pixels[0..4], &[10, 20, 30, 0]);
-        assert_eq!(&pixels[4..8], &[40, 50, 60, 128]);
+        assert_eq!(icon.size, [16, 16]);
+        assert_eq!(icon.pixels[0].to_srgba_unmultiplied()[3], 0);
+        assert_eq!(icon.pixels[1].to_srgba_unmultiplied(), [40, 50, 60, 128]);
     }
 }

--- a/rust/src/ui/game_hud.rs
+++ b/rust/src/ui/game_hud.rs
@@ -167,7 +167,7 @@ pub fn init_resource_icons(
 
     for (name, img) in pending {
         let h = images.add(img);
-        let tex = contexts.add_image(bevy_egui::EguiTextureHandle::Weak(h.id()));
+        let tex = contexts.add_image(bevy_egui::EguiTextureHandle::Strong(h.clone()));
         match name {
             "food" => cache.food = Some(tex),
             "gold" => cache.gold = Some(tex),
@@ -194,7 +194,8 @@ fn resource_icon(
 ) {
     let icon_size = 16.0;
     let spacing = 2.0;
-    ui.horizontal(|ui| {
+    // Force left-to-right so icon:value order is correct even inside RTL parent
+    ui.with_layout(egui::Layout::left_to_right(egui::Align::Center), |ui| {
         ui.spacing_mut().item_spacing.x = spacing;
         if let Some(tex_id) = tex {
             ui.add(
@@ -210,7 +211,7 @@ fn resource_icon(
                 ui.allocate_exact_size(egui::vec2(icon_size, icon_size), egui::Sense::hover());
             ui.painter().rect_filled(rect, 2.0, color);
         }
-        ui.label(egui::RichText::new(format!("{amount}")).color(color));
+        ui.label(egui::RichText::new(amount.to_string()).color(color));
     })
     .response
     .on_hover_text(tip);

--- a/rust/src/ui/game_hud.rs
+++ b/rust/src/ui/game_hud.rs
@@ -127,11 +127,6 @@ fn resource_icon_spec(icon: HudResourceIcon) -> ResourceIconSpec {
     }
 }
 
-fn resource_icon_uv(icon: HudResourceIcon, atlas_w: u32, atlas_h: u32) -> egui::Rect {
-    let spec = resource_icon_spec(icon);
-    cell_uv(spec.col, spec.row, atlas_w, atlas_h)
-}
-
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum ResourceIconPart {
     Icon,
@@ -146,55 +141,94 @@ fn resource_icon_parts(prefer_right_to_left: bool) -> [ResourceIconPart; 2] {
     }
 }
 
-/// Cached egui texture IDs + UV rects for resource icons from atlas spritesheets.
+/// Cached egui texture IDs for resource icons extracted from atlas sprites.
 #[derive(Resource, Default)]
 pub struct ResourceIconCache {
     pub initialized: bool,
-    pub world_tex: Option<egui::TextureId>,
-    pub food_uv: Option<egui::Rect>,
-    pub gold_uv: Option<egui::Rect>,
-    pub wood_uv: Option<egui::Rect>,
-    pub stone_uv: Option<egui::Rect>,
+    pub food: Option<egui::TextureId>,
+    pub gold: Option<egui::TextureId>,
+    pub wood: Option<egui::TextureId>,
+    pub stone: Option<egui::TextureId>,
 }
 
-/// Compute UV rect for a cell in a 17px-cell atlas.
-fn cell_uv(col: u32, row: u32, atlas_w: u32, atlas_h: u32) -> egui::Rect {
-    let cell = 17.0;
-    let sprite = 16.0;
-    let x = col as f32 * cell;
-    let y = row as f32 * cell;
-    egui::Rect::from_min_max(
-        egui::pos2(x / atlas_w as f32, y / atlas_h as f32),
-        egui::pos2((x + sprite) / atlas_w as f32, (y + sprite) / atlas_h as f32),
-    )
+/// Extract a single 16x16 sprite from a 17px-cell atlas at (col, row).
+fn extract_atlas_cell(atlas: &Image, col: u32, row: u32, cell_size: u32) -> Option<Image> {
+    let sprite_size = cell_size - 1;
+    let src_w = atlas.width();
+    let src_data = atlas.data.as_ref()?;
+    let px = col * cell_size;
+    let py = row * cell_size;
+    let mut data = vec![0u8; (sprite_size * sprite_size * 4) as usize];
+    for y in 0..sprite_size {
+        for x in 0..sprite_size {
+            let sx = (px + x) as usize;
+            let sy = (py + y) as usize;
+            let src_idx = (sy * src_w as usize + sx) * 4;
+            let dst_idx = (y * sprite_size + x) as usize * 4;
+            if src_idx + 3 < src_data.len() {
+                data[dst_idx..dst_idx + 4].copy_from_slice(&src_data[src_idx..src_idx + 4]);
+            }
+        }
+    }
+    Some(Image::new(
+        bevy::render::render_resource::Extent3d {
+            width: sprite_size,
+            height: sprite_size,
+            depth_or_array_layers: 1,
+        },
+        bevy::render::render_resource::TextureDimension::D2,
+        data,
+        bevy::render::render_resource::TextureFormat::Rgba8UnormSrgb,
+        Default::default(),
+    ))
 }
 
-/// Register atlas textures with egui and compute UV rects for each resource icon.
+/// Extract world-atlas cells into standalone icon textures so alpha stays intact in egui.
 pub fn init_resource_icons(
     mut cache: ResMut<ResourceIconCache>,
     mut contexts: EguiContexts,
     sprites: Res<crate::render::SpriteAssets>,
-    images: Res<Assets<Image>>,
+    mut images: ResMut<Assets<Image>>,
 ) {
-    // All four HUD resources live on the world atlas, not the character atlas.
-    if cache.world_tex.is_none() {
-        if let Some(a) = images.get(&sprites.world_texture) {
-            let tex = contexts.add_image(bevy_egui::EguiTextureHandle::Weak(
-                sprites.world_texture.id(),
-            ));
-            let (w, h) = (a.width(), a.height());
-            cache.world_tex = Some(tex);
-            cache.food_uv = Some(resource_icon_uv(HudResourceIcon::Food, w, h));
-            cache.gold_uv = Some(resource_icon_uv(HudResourceIcon::Gold, w, h));
-            cache.wood_uv = Some(resource_icon_uv(HudResourceIcon::Wood, w, h));
-            cache.stone_uv = Some(resource_icon_uv(HudResourceIcon::Stone, w, h));
+    let cell = 17u32;
+    let mut pending: Vec<(HudResourceIcon, Image)> = Vec::new();
+    if let Some(atlas) = images.get(&sprites.world_texture) {
+        for icon in [
+            HudResourceIcon::Food,
+            HudResourceIcon::Gold,
+            HudResourceIcon::Wood,
+            HudResourceIcon::Stone,
+        ] {
+            let missing = match icon {
+                HudResourceIcon::Food => cache.food.is_none(),
+                HudResourceIcon::Gold => cache.gold.is_none(),
+                HudResourceIcon::Wood => cache.wood.is_none(),
+                HudResourceIcon::Stone => cache.stone.is_none(),
+            };
+            if !missing {
+                continue;
+            }
+
+            let spec = resource_icon_spec(icon);
+            if let Some(img) = extract_atlas_cell(atlas, spec.col, spec.row, cell) {
+                pending.push((icon, img));
+            }
         }
     }
-    cache.initialized = cache.world_tex.is_some()
-        && cache.food_uv.is_some()
-        && cache.gold_uv.is_some()
-        && cache.wood_uv.is_some()
-        && cache.stone_uv.is_some();
+    for (icon, img) in pending {
+        let handle = images.add(img);
+        let tex = contexts.add_image(bevy_egui::EguiTextureHandle::Strong(handle));
+        match icon {
+            HudResourceIcon::Food => cache.food = Some(tex),
+            HudResourceIcon::Gold => cache.gold = Some(tex),
+            HudResourceIcon::Wood => cache.wood = Some(tex),
+            HudResourceIcon::Stone => cache.stone = Some(tex),
+        }
+    }
+    cache.initialized = cache.food.is_some()
+        && cache.gold.is_some()
+        && cache.wood.is_some()
+        && cache.stone.is_some();
 }
 
 /// Render a resource sprite icon + amount with tooltip.
@@ -202,8 +236,7 @@ pub fn init_resource_icons(
 fn resource_icon(
     ui: &mut egui::Ui,
     amount: i32,
-    atlas_tex: Option<egui::TextureId>,
-    uv: Option<egui::Rect>,
+    tex: Option<egui::TextureId>,
     color: egui::Color32,
     tip: &str,
 ) {
@@ -215,13 +248,12 @@ fn resource_icon(
         for part in parts {
             match part {
                 ResourceIconPart::Icon => {
-                    if let (Some(tex_id), Some(uv_rect)) = (atlas_tex, uv) {
+                    if let Some(tex_id) = tex {
                         ui.add(
                             egui::Image::new(egui::load::SizedTexture::new(
                                 tex_id,
                                 [icon_size, icon_size],
                             ))
-                            .uv(uv_rect)
                             .tint(egui::Color32::WHITE),
                         );
                     } else {
@@ -535,32 +567,28 @@ pub fn top_bar_system(
                     resource_icon(
                         ui,
                         town_wood,
-                        icon_cache.world_tex,
-                        icon_cache.wood_uv,
+                        icon_cache.wood,
                         egui::Color32::from_rgb(150, 110, 70),
                         catalog.0.get("wood").unwrap_or(&""),
                     );
                     resource_icon(
                         ui,
                         town_stone,
-                        icon_cache.world_tex,
-                        icon_cache.stone_uv,
+                        icon_cache.stone,
                         egui::Color32::from_rgb(170, 170, 180),
                         catalog.0.get("stone").unwrap_or(&""),
                     );
                     resource_icon(
                         ui,
                         town_food,
-                        icon_cache.world_tex,
-                        icon_cache.food_uv,
+                        icon_cache.food,
                         egui::Color32::from_rgb(120, 200, 80),
                         catalog.0.get("food").unwrap_or(&""),
                     );
                     resource_icon(
                         ui,
                         town_gold,
-                        icon_cache.world_tex,
-                        icon_cache.gold_uv,
+                        icon_cache.gold,
                         egui::Color32::from_rgb(220, 190, 50),
                         catalog.0.get("gold").unwrap_or(&""),
                     );
@@ -3647,5 +3675,29 @@ mod tests {
             resource_icon_parts(true),
             [ResourceIconPart::Value, ResourceIconPart::Icon]
         );
+    }
+
+    #[test]
+    fn extract_atlas_cell_preserves_alpha() {
+        let cell_size = 17u32;
+        let mut data = vec![0u8; (cell_size * cell_size * 4) as usize];
+        data[0..4].copy_from_slice(&[10, 20, 30, 0]);
+        data[4..8].copy_from_slice(&[40, 50, 60, 128]);
+        let atlas = Image::new(
+            bevy::render::render_resource::Extent3d {
+                width: cell_size,
+                height: cell_size,
+                depth_or_array_layers: 1,
+            },
+            bevy::render::render_resource::TextureDimension::D2,
+            data,
+            bevy::render::render_resource::TextureFormat::Rgba8UnormSrgb,
+            Default::default(),
+        );
+
+        let icon = extract_atlas_cell(&atlas, 0, 0, cell_size).expect("cell should extract");
+        let pixels = icon.data.as_ref().expect("icon image should contain data");
+        assert_eq!(&pixels[0..4], &[10, 20, 30, 0]);
+        assert_eq!(&pixels[4..8], &[40, 50, 60, 128]);
     }
 }


### PR DESCRIPTION
## Summary
- Forces left-to-right layout inside `resource_icon()` so icon:value order is correct even inside the RTL top bar
- Switches from `EguiTextureHandle::Weak` to `Strong` so egui properly co-owns the extracted atlas sprites (fixes food/gold icons not rendering)

## Test plan
- [x] cargo clippy --release -- -D warnings clean
- [ ] Visual: icons appear before numbers, all 4 resource types show atlas sprites

Closes #64