### PR TITLE
feature: box/rectangle drag placement for buildings

### DIFF
--- a/rust/src/ui/mod.rs
+++ b/rust/src/ui/mod.rs
@@ -1545,6 +1545,46 @@ fn screen_to_world(
     position + mouse_offset / zoom
 }
 
+/// Bresenham-style integer line over grid slots, inclusive of start/end.
+fn slots_on_line(start: (usize, usize), end: (usize, usize)) -> Vec<(usize, usize)> {
+    let (mut c0, mut r0) = (start.0 as i32, start.1 as i32);
+    let (c1, r1) = (end.0 as i32, end.1 as i32);
+    let dc = (c1 - c0).abs();
+    let dr = (r1 - r0).abs();
+    let sc: i32 = if c0 < c1 {
+        1
+    } else if c0 > c1 {
+        -1
+    } else {
+        0
+    };
+    let sr: i32 = if r0 < r1 {
+        1
+    } else if r0 > r1 {
+        -1
+    } else {
+        0
+    };
+    let mut err = dc - dr;
+    let mut out = Vec::new();
+    loop {
+        out.push((c0 as usize, r0 as usize));
+        if c0 == c1 && r0 == r1 {
+            break;
+        }
+        let e2 = 2 * err;
+        if e2 > -dr {
+            err -= dr;
+            c0 += sc;
+        }
+        if e2 < dc {
+            err += dc;
+            r0 += sr;
+        }
+    }
+    out
+}
+
 /// All grid slots in the axis-aligned rectangle between two corners, inclusive.
 fn slots_in_box(start: (usize, usize), end: (usize, usize)) -> Vec<(usize, usize)> {
     let c_min = start.0.min(end.0);
@@ -1558,6 +1598,19 @@ fn slots_in_box(start: (usize, usize), end: (usize, usize)) -> Vec<(usize, usize
         }
     }
     out
+}
+
+/// Choose line or box drag shape based on Shift key state.
+fn drag_shape_slots(
+    start: (usize, usize),
+    end: (usize, usize),
+    keys: &ButtonInput<KeyCode>,
+) -> Vec<(usize, usize)> {
+    if keys.pressed(KeyCode::ShiftLeft) || keys.pressed(KeyCode::ShiftRight) {
+        slots_in_box(start, end)
+    } else {
+        slots_on_line(start, end)
+    }
 }
 
 /// Right-click cancels active build placement.
@@ -1577,6 +1630,7 @@ fn slot_right_click_system(
 fn build_place_click_system(
     mut commands: Commands,
     mouse: Res<ButtonInput<MouseButton>>,
+    keys: Res<ButtonInput<KeyCode>>,
     windows: Query<&Window>,
     camera_query: Query<(&Transform, &Projection), With<crate::render::MainCamera>>,
     mut egui_contexts: bevy_egui::EguiContexts,
@@ -1725,7 +1779,7 @@ fn build_place_click_system(
         return;
     }
 
-    // Road: drag placement on world grid (reuses drag_start_slot/slots_in_box)
+    // Road: drag placement on world grid (line default, Shift for box fill)
     if kind.is_road() {
         if just_pressed {
             build_ctx.drag_start_slot = Some((gc, gr));
@@ -1743,7 +1797,7 @@ fn build_place_click_system(
         let mut placed = 0usize;
         let mut upgraded = 0usize;
         let mut last_err: Option<&str> = None;
-        for (sc, sr) in slots_in_box(start, end) {
+        for (sc, sr) in drag_shape_slots(start, end, &keys) {
             let cell_pos = world_state.grid.grid_to_world(sc, sr);
             match world_state.place_building(
                 &mut food_val,
@@ -1868,7 +1922,7 @@ fn build_place_click_system(
     let end = build_ctx.drag_current_slot.take().unwrap_or((gc, gr));
     let mut placed = 0usize;
     let mut first_placed: Option<(usize, usize)> = None;
-    for (sc, sr) in slots_in_box(start, end) {
+    for (sc, sr) in drag_shape_slots(start, end, &keys) {
         if try_place_at_slot(sc, sr, &mut last_place_err) {
             if first_placed.is_none() {
                 first_placed = Some((sc, sr));
@@ -1942,6 +1996,7 @@ struct BuildGhostTrail;
 /// Update or spawn/despawn the ghost sprite to preview building placement.
 fn build_ghost_system(
     mut commands: Commands,
+    keys: Res<ButtonInput<KeyCode>>,
     windows: Query<&Window>,
     camera_query: Query<(&Transform, &Projection), With<crate::render::MainCamera>>,
     mut egui_contexts: bevy_egui::EguiContexts,
@@ -2062,7 +2117,7 @@ fn build_ghost_system(
         let path = match build_ctx.drag_start_slot {
             Some(start) => {
                 build_ctx.drag_current_slot = Some((gc, gr));
-                slots_in_box(start, (gc, gr))
+                drag_shape_slots(start, (gc, gr), &keys)
             }
             None => vec![(gc, gr)],
         };
@@ -2208,7 +2263,7 @@ fn build_ghost_system(
     let mut drag_preview: Vec<(usize, usize, bool, bool)> = Vec::new();
     {
         let path = match (build_ctx.drag_start_slot, build_ctx.drag_current_slot) {
-            (Some(start), Some(end)) => slots_in_box(start, end),
+            (Some(start), Some(end)) => drag_shape_slots(start, end, &keys),
             _ => vec![(gc, gr)],
         };
         let cost = crate::constants::building_cost(kind);

--- a/rust/src/ui/mod.rs
+++ b/rust/src/ui/mod.rs
@@ -1560,61 +1560,6 @@ fn slots_in_box(start: (usize, usize), end: (usize, usize)) -> Vec<(usize, usize
     out
 }
 
-/// Returns cells for drag placement: box (filled rectangle) when `box_mode` is true,
-/// Bresenham line otherwise.
-fn drag_shape_slots(
-    start: (usize, usize),
-    end: (usize, usize),
-    box_mode: bool,
-) -> Vec<(usize, usize)> {
-    if box_mode {
-        slots_in_box(start, end)
-    } else {
-        slots_on_line(start, end)
-    }
-}
-
-/// Bresenham-style integer line over town-grid slots, inclusive of start/end.
-fn slots_on_line(start: (usize, usize), end: (usize, usize)) -> Vec<(usize, usize)> {
-    let (mut c0, mut r0) = (start.0 as i32, start.1 as i32);
-    let (c1, r1) = (end.0 as i32, end.1 as i32);
-    let dc = (c1 - c0).abs();
-    let dr = (r1 - r0).abs();
-    let sc: i32 = if c0 < c1 {
-        1
-    } else if c0 > c1 {
-        -1
-    } else {
-        0
-    };
-    let sr: i32 = if r0 < r1 {
-        1
-    } else if r0 > r1 {
-        -1
-    } else {
-        0
-    };
-    let mut err = dc - dr;
-
-    let mut out = Vec::new();
-    loop {
-        out.push((c0 as usize, r0 as usize));
-        if c0 == c1 && r0 == r1 {
-            break;
-        }
-        let e2 = 2 * err;
-        if e2 > -dr {
-            err -= dr;
-            c0 += sc;
-        }
-        if e2 < dc {
-            err += dc;
-            r0 += sr;
-        }
-    }
-    out
-}
-
 /// Right-click cancels active build placement.
 fn slot_right_click_system(
     mouse: Res<ButtonInput<MouseButton>>,
@@ -1632,7 +1577,6 @@ fn slot_right_click_system(
 fn build_place_click_system(
     mut commands: Commands,
     mouse: Res<ButtonInput<MouseButton>>,
-    keys: Res<ButtonInput<KeyCode>>,
     windows: Query<&Window>,
     camera_query: Query<(&Transform, &Projection), With<crate::render::MainCamera>>,
     mut egui_contexts: bevy_egui::EguiContexts,
@@ -1781,7 +1725,7 @@ fn build_place_click_system(
         return;
     }
 
-    // Road: drag-line placement on world grid (reuses drag_start_slot/slots_on_line)
+    // Road: drag placement on world grid (reuses drag_start_slot/slots_in_box)
     if kind.is_road() {
         if just_pressed {
             build_ctx.drag_start_slot = Some((gc, gr));
@@ -1799,8 +1743,7 @@ fn build_place_click_system(
         let mut placed = 0usize;
         let mut upgraded = 0usize;
         let mut last_err: Option<&str> = None;
-        let box_mode = keys.pressed(KeyCode::ShiftLeft) || keys.pressed(KeyCode::ShiftRight);
-        for (sc, sr) in drag_shape_slots(start, end, box_mode) {
+        for (sc, sr) in slots_in_box(start, end) {
             let cell_pos = world_state.grid.grid_to_world(sc, sr);
             match world_state.place_building(
                 &mut food_val,
@@ -1923,10 +1866,9 @@ fn build_place_click_system(
 
     let start = build_ctx.drag_start_slot.take().unwrap_or((gc, gr));
     let end = build_ctx.drag_current_slot.take().unwrap_or((gc, gr));
-    let box_mode = keys.pressed(KeyCode::ShiftLeft) || keys.pressed(KeyCode::ShiftRight);
     let mut placed = 0usize;
     let mut first_placed: Option<(usize, usize)> = None;
-    for (sc, sr) in drag_shape_slots(start, end, box_mode) {
+    for (sc, sr) in slots_in_box(start, end) {
         if try_place_at_slot(sc, sr, &mut last_place_err) {
             if first_placed.is_none() {
                 first_placed = Some((sc, sr));
@@ -2001,7 +1943,6 @@ struct BuildGhostTrail;
 fn build_ghost_system(
     mut commands: Commands,
     windows: Query<&Window>,
-    keys: Res<ButtonInput<KeyCode>>,
     camera_query: Query<(&Transform, &Projection), With<crate::render::MainCamera>>,
     mut egui_contexts: bevy_egui::EguiContexts,
     mut build_ctx: ResMut<BuildMenuContext>,
@@ -2118,11 +2059,10 @@ fn build_ghost_system(
         let snapped = grid.grid_to_world(gc, gr);
         build_ctx.hover_world_pos = snapped;
 
-        let box_mode = keys.pressed(KeyCode::ShiftLeft) || keys.pressed(KeyCode::ShiftRight);
         let path = match build_ctx.drag_start_slot {
             Some(start) => {
                 build_ctx.drag_current_slot = Some((gc, gr));
-                drag_shape_slots(start, (gc, gr), box_mode)
+                slots_in_box(start, (gc, gr))
             }
             None => vec![(gc, gr)],
         };
@@ -2265,11 +2205,10 @@ fn build_ghost_system(
     let (cc, cr) = grid.world_to_grid(center);
     let is_center = gc == cc && gr == cr;
 
-    let box_mode = keys.pressed(KeyCode::ShiftLeft) || keys.pressed(KeyCode::ShiftRight);
     let mut drag_preview: Vec<(usize, usize, bool, bool)> = Vec::new();
     {
         let path = match (build_ctx.drag_start_slot, build_ctx.drag_current_slot) {
-            (Some(start), Some(end)) => drag_shape_slots(start, end, box_mode),
+            (Some(start), Some(end)) => slots_in_box(start, end),
             _ => vec![(gc, gr)],
         };
         let cost = crate::constants::building_cost(kind);

--- a/rust/src/ui/mod.rs
+++ b/rust/src/ui/mod.rs
@@ -1545,7 +1545,7 @@ fn screen_to_world(
     position + mouse_offset / zoom
 }
 
-/// Bresenham-style integer line over town-grid slots, inclusive of start/end.
+/// All grid slots in the axis-aligned rectangle between two corners, inclusive.
 fn slots_in_box(start: (usize, usize), end: (usize, usize)) -> Vec<(usize, usize)> {
     let c_min = start.0.min(end.0);
     let c_max = start.0.max(end.0);
@@ -1574,6 +1574,7 @@ fn drag_shape_slots(
     }
 }
 
+/// Bresenham-style integer line over town-grid slots, inclusive of start/end.
 fn slots_on_line(start: (usize, usize), end: (usize, usize)) -> Vec<(usize, usize)> {
     let (mut c0, mut r0) = (start.0 as i32, start.1 as i32);
     let (c1, r1) = (end.0 as i32, end.1 as i32);

--- a/rust/src/ui/mod.rs
+++ b/rust/src/ui/mod.rs
@@ -1546,6 +1546,34 @@ fn screen_to_world(
 }
 
 /// Bresenham-style integer line over town-grid slots, inclusive of start/end.
+fn slots_in_box(start: (usize, usize), end: (usize, usize)) -> Vec<(usize, usize)> {
+    let c_min = start.0.min(end.0);
+    let c_max = start.0.max(end.0);
+    let r_min = start.1.min(end.1);
+    let r_max = start.1.max(end.1);
+    let mut out = Vec::with_capacity((c_max - c_min + 1) * (r_max - r_min + 1));
+    for r in r_min..=r_max {
+        for c in c_min..=c_max {
+            out.push((c, r));
+        }
+    }
+    out
+}
+
+/// Returns cells for drag placement: box (filled rectangle) when `box_mode` is true,
+/// Bresenham line otherwise.
+fn drag_shape_slots(
+    start: (usize, usize),
+    end: (usize, usize),
+    box_mode: bool,
+) -> Vec<(usize, usize)> {
+    if box_mode {
+        slots_in_box(start, end)
+    } else {
+        slots_on_line(start, end)
+    }
+}
+
 fn slots_on_line(start: (usize, usize), end: (usize, usize)) -> Vec<(usize, usize)> {
     let (mut c0, mut r0) = (start.0 as i32, start.1 as i32);
     let (c1, r1) = (end.0 as i32, end.1 as i32);
@@ -1603,6 +1631,7 @@ fn slot_right_click_system(
 fn build_place_click_system(
     mut commands: Commands,
     mouse: Res<ButtonInput<MouseButton>>,
+    keys: Res<ButtonInput<KeyCode>>,
     windows: Query<&Window>,
     camera_query: Query<(&Transform, &Projection), With<crate::render::MainCamera>>,
     mut egui_contexts: bevy_egui::EguiContexts,
@@ -1769,7 +1798,8 @@ fn build_place_click_system(
         let mut placed = 0usize;
         let mut upgraded = 0usize;
         let mut last_err: Option<&str> = None;
-        for (sc, sr) in slots_on_line(start, end) {
+        let box_mode = keys.pressed(KeyCode::ShiftLeft) || keys.pressed(KeyCode::ShiftRight);
+        for (sc, sr) in drag_shape_slots(start, end, box_mode) {
             let cell_pos = world_state.grid.grid_to_world(sc, sr);
             match world_state.place_building(
                 &mut food_val,
@@ -1892,9 +1922,10 @@ fn build_place_click_system(
 
     let start = build_ctx.drag_start_slot.take().unwrap_or((gc, gr));
     let end = build_ctx.drag_current_slot.take().unwrap_or((gc, gr));
+    let box_mode = keys.pressed(KeyCode::ShiftLeft) || keys.pressed(KeyCode::ShiftRight);
     let mut placed = 0usize;
     let mut first_placed: Option<(usize, usize)> = None;
-    for (sc, sr) in slots_on_line(start, end) {
+    for (sc, sr) in drag_shape_slots(start, end, box_mode) {
         if try_place_at_slot(sc, sr, &mut last_place_err) {
             if first_placed.is_none() {
                 first_placed = Some((sc, sr));
@@ -1969,6 +2000,7 @@ struct BuildGhostTrail;
 fn build_ghost_system(
     mut commands: Commands,
     windows: Query<&Window>,
+    keys: Res<ButtonInput<KeyCode>>,
     camera_query: Query<(&Transform, &Projection), With<crate::render::MainCamera>>,
     mut egui_contexts: bevy_egui::EguiContexts,
     mut build_ctx: ResMut<BuildMenuContext>,
@@ -2085,10 +2117,11 @@ fn build_ghost_system(
         let snapped = grid.grid_to_world(gc, gr);
         build_ctx.hover_world_pos = snapped;
 
+        let box_mode = keys.pressed(KeyCode::ShiftLeft) || keys.pressed(KeyCode::ShiftRight);
         let path = match build_ctx.drag_start_slot {
             Some(start) => {
                 build_ctx.drag_current_slot = Some((gc, gr));
-                slots_on_line(start, (gc, gr))
+                drag_shape_slots(start, (gc, gr), box_mode)
             }
             None => vec![(gc, gr)],
         };
@@ -2231,10 +2264,11 @@ fn build_ghost_system(
     let (cc, cr) = grid.world_to_grid(center);
     let is_center = gc == cc && gr == cr;
 
+    let box_mode = keys.pressed(KeyCode::ShiftLeft) || keys.pressed(KeyCode::ShiftRight);
     let mut drag_preview: Vec<(usize, usize, bool, bool)> = Vec::new();
     {
         let path = match (build_ctx.drag_start_slot, build_ctx.drag_current_slot) {
-            (Some(start), Some(end)) => slots_on_line(start, end),
+            (Some(start), Some(end)) => drag_shape_slots(start, end, box_mode),
             _ => vec![(gc, gr)],
         };
         let cost = crate::constants::building_cost(kind);


### PR DESCRIPTION
Closes #76

## Summary

- Add `slots_in_box()` helper that returns all grid cells in a rectangle between two corner points
- Add `drag_shape_slots()` dispatcher that picks line (Bresenham) or box based on a `box_mode` flag
- Hold **Shift** during drag to switch from line placement to filled rectangle placement
- Works for both road (world-grid) and town-grid building placement paths
- Preview ghosts render the full rectangle area when Shift is held
- Per-cell validation (terrain, occupancy, cost budget) unchanged -- invalid cells within the box are skipped

## Changes

- `rust/src/ui/mod.rs`: added `slots_in_box`, `drag_shape_slots`; added `keys: Res<ButtonInput<KeyCode>>` to `build_place_click_system` and `build_ghost_system`; updated 4 call sites from `slots_on_line` to `drag_shape_slots` with Shift key check