### PR TITLE
feat: expose missing player controls to BRP/LLM agents

### DIFF
--- a/docs/brp.md
+++ b/docs/brp.md
@@ -259,6 +259,12 @@ Set town behavior policies. Only provided fields are changed.
 | `archer_flee_hp` | f32 | no | Archer flee HP threshold |
 | `recovery_hp` | f32 | no | HP % to resume work after healing |
 | `mining_radius` | f32 | no | Gold mine discovery radius |
+| `reserve_food` | i32 | no | AI won't spend food below this |
+| `reserve_gold` | i32 | no | AI won't spend gold below this |
+| `archer_schedule` | string | no | "Both", "DayOnly", or "NightOnly" |
+| `farmer_schedule` | string | no | "Both", "DayOnly", or "NightOnly" |
+| `archer_off_duty` | string | no | "GoToBed", "StayAtFountain", or "WanderTown" |
+| `farmer_off_duty` | string | no | "GoToBed", "StayAtFountain", or "WanderTown" |
 
 ```bash
 curl -s -X POST http://localhost:15702 -H "Content-Type: application/json" \
@@ -281,17 +287,69 @@ curl -s -X POST http://localhost:15702 -H "Content-Type: application/json" \
 
 ### endless/squad_target
 
-Set a movement target for a military squad.
+Set or clear a movement target for a military squad. Omit x/y to clear the target.
 
 | Param | Type | Required | Description |
 |-------|------|----------|-------------|
 | `squad` | usize | yes | Squad index |
-| `x` | f32 | yes | Target X position |
-| `y` | f32 | yes | Target Y position |
+| `x` | f32 | no | Target X position (omit to clear) |
+| `y` | f32 | no | Target Y position (omit to clear) |
+
+```bash
+# Set target
+curl -s -X POST http://localhost:15702 -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"endless/squad_target","params":{"squad":0,"x":500.0,"y":300.0},"id":1}'
+
+# Clear target
+curl -s -X POST http://localhost:15702 -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"endless/squad_target","params":{"squad":0},"id":1}'
+```
+
+### endless/squad
+
+Set squad behavior settings. Only provided fields are changed.
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `squad` | usize | yes | Squad index |
+| `patrol_enabled` | bool | no | Members patrol waypoints when no target |
+| `rest_when_tired` | bool | no | Members go home to rest when tired |
+| `hold_fire` | bool | no | Members only attack ManualTarget |
+| `loot_threshold` | usize | no | Equipment count to trigger loot return (1-20) |
 
 ```bash
 curl -s -X POST http://localhost:15702 -H "Content-Type: application/json" \
-  -d '{"jsonrpc":"2.0","method":"endless/squad_target","params":{"squad":0,"x":500.0,"y":300.0},"id":1}'
+  -d '{"jsonrpc":"2.0","method":"endless/squad","params":{"squad":0,"patrol_enabled":true,"hold_fire":false},"id":1}'
+```
+
+### endless/squad_recruit
+
+Recruit NPCs of a military job into a squad.
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `squad` | usize | yes | Squad index |
+| `job` | string | yes | Military job name (e.g. "Archer", "Fighter", "Crossbow") |
+| `count` | usize | no | Number to recruit (default 1) |
+
+```bash
+curl -s -X POST http://localhost:15702 -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"endless/squad_recruit","params":{"squad":0,"job":"Archer","count":5},"id":1}'
+```
+
+### endless/squad_dismiss
+
+Dismiss NPCs from a squad, optionally filtered by job.
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `squad` | usize | yes | Squad index |
+| `job` | string | no | Filter by job (omit to dismiss any) |
+| `count` | usize | no | Number to dismiss (default 1) |
+
+```bash
+curl -s -X POST http://localhost:15702 -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"endless/squad_dismiss","params":{"squad":0,"job":"Archer","count":3},"id":1}'
 ```
 
 ### endless/ai_manager

--- a/docs/control-parity.md
+++ b/docs/control-parity.md
@@ -36,26 +36,26 @@ Last updated: 2026-03-15.
 | archer_flee_hp | slider | `endless/policy` | `policy` | personality default |
 | recovery_hp | slider | `endless/policy` | `policy` | personality default |
 | mining_radius | slider | `endless/policy` | `policy` | `ExpandMiningRadius` |
-| reserve_food | slider | -- | -- | reads internally |
-| reserve_gold | slider | -- | -- | reads internally |
-| archer_schedule | dropdown | -- | -- | -- |
-| archer_off_duty | dropdown | -- | -- | -- |
-| farmer_schedule | dropdown | -- | -- | -- |
-| farmer_off_duty | dropdown | -- | -- | -- |
-| loot_threshold (per-squad) | slider (squad tab) | readable via `endless/debug` | -- | personality default |
+| reserve_food | slider | `endless/policy` | `policy` | reads internally |
+| reserve_gold | slider | `endless/policy` | `policy` | reads internally |
+| archer_schedule | dropdown | `endless/policy` | `policy` | -- |
+| archer_off_duty | dropdown | `endless/policy` | `policy` | -- |
+| farmer_schedule | dropdown | `endless/policy` | `policy` | -- |
+| farmer_off_duty | dropdown | `endless/policy` | `policy` | -- |
+| loot_threshold (per-squad) | slider (squad tab) | `endless/squad` | `squad` | personality default |
 
 ## Squad
 
 | Capability | Player UI | BRP API | LLM Player | Built-in AI |
 |---|---|---|---|---|
 | Set squad target | click map | `endless/squad_target` | `squad_target` | `ai_squad_commander` |
-| Clear squad target | button | -- | -- | `ai_squad_commander` |
-| patrol_enabled | checkbox | -- | -- | sets internally |
-| rest_when_tired | checkbox | -- | -- | sets internally |
-| hold_fire | checkbox | -- | -- | intentionally off |
-| loot_threshold | slider | -- | -- | personality default |
-| Recruit to squad | per-job buttons | -- | -- | auto-assigns |
-| Dismiss from squad | button | -- | -- | -- |
+| Clear squad target | button | `endless/squad_target` (omit x/y) | `squad_target` (omit x/y) | `ai_squad_commander` |
+| patrol_enabled | checkbox | `endless/squad` | `squad` | sets internally |
+| rest_when_tired | checkbox | `endless/squad` | `squad` | sets internally |
+| hold_fire | checkbox | `endless/squad` | `squad` | intentionally off |
+| loot_threshold | slider | `endless/squad` | `squad` | personality default |
+| Recruit to squad | per-job buttons | `endless/squad_recruit` | -- | auto-assigns |
+| Dismiss from squad | button | `endless/squad_dismiss` | -- | -- |
 | Direct control (box-select) | mouse select | -- | -- | -- |
 
 ## Meta / AI Manager
@@ -74,11 +74,11 @@ Capabilities the player has that AI surfaces are missing.
 
 ### BRP / LLM Player
 
-1. **Schedule controls** -- `archer_schedule`, `farmer_schedule`, `archer_off_duty`, `farmer_off_duty` not exposed
-2. **Reserve food/gold** -- `reserve_food`, `reserve_gold` not exposed
-3. **Squad settings** -- `patrol_enabled`, `rest_when_tired`, `hold_fire`, `loot_threshold` not settable (only readable via `endless/debug`)
-4. **Squad recruit/dismiss** -- no action to move NPCs between squads
-5. **Clear squad target** -- `endless/squad_target` can set but not clear (would need null target support)
+1. ~~**Schedule controls**~~ -- closed: `endless/policy` + LLM `policy` action
+2. ~~**Reserve food/gold**~~ -- closed: `endless/policy` + LLM `policy` action
+3. ~~**Squad settings**~~ -- closed: `endless/squad` + LLM `squad` action
+4. ~~**Squad recruit/dismiss**~~ -- closed: `endless/squad_recruit` + `endless/squad_dismiss` (BRP only)
+5. ~~**Clear squad target**~~ -- closed: omit x/y in `endless/squad_target` or LLM `squad_target`
 6. **Wall upgrades** -- no endpoint to upgrade walls
 7. **Mine enable/disable** -- no endpoint to toggle individual mines
 
@@ -88,17 +88,11 @@ Capabilities the player has that AI surfaces are missing.
 2. **Schedule/off-duty tuning** -- does not change archer/farmer schedules or off-duty behavior
 3. **Wall upgrades** -- does not upgrade walls
 
-### By Impact
+### Remaining Gaps
 
-Highest impact for competitive AI parity:
-
-- **Squad settings via BRP** (patrol, rest, hold_fire, loot_threshold, recruit/dismiss) -- military effectiveness
-- **Schedule/reserve via BRP** (schedules, off-duty, reserve_food/gold) -- economic tuning
-- **Schedule/off-duty tuning for built-in AI** -- still fixed at default policy values
-- **Clear squad target via BRP** -- needed for retreat/disengage
-
-Lower impact:
+Lower priority:
 
 - Wall upgrades (marginal defensive value vs effort)
 - Mine enable/disable (niche optimization)
 - Direct control (intentionally player-only)
+- Squad recruit/dismiss for LLM player (BRP-only for now)

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -398,6 +398,15 @@ pub fn build_app(app: &mut App) {
                     "endless/squad_target",
                     systems::remote::squad_target_handler,
                 )
+                .with_method("endless/squad", systems::remote::squad_handler)
+                .with_method(
+                    "endless/squad_recruit",
+                    systems::remote::squad_recruit_handler,
+                )
+                .with_method(
+                    "endless/squad_dismiss",
+                    systems::remote::squad_dismiss_handler,
+                )
                 .with_method("endless/ai_manager", systems::remote::ai_manager_handler)
                 .with_method("endless/chat", systems::remote::chat_handler)
                 .with_method("endless/debug", systems::remote::debug_handler)

--- a/rust/src/systems/llm_player.rs
+++ b/rust/src/systems/llm_player.rs
@@ -661,6 +661,36 @@ fn execute_actions(
                                     policy.0.mining_radius = v.clamp(0.0, 5000.0);
                                 }
                             }
+                            "reserve_food" => {
+                                if let Ok(v) = val.parse::<i32>() {
+                                    policy.0.reserve_food = v.max(0);
+                                }
+                            }
+                            "reserve_gold" => {
+                                if let Ok(v) = val.parse::<i32>() {
+                                    policy.0.reserve_gold = v.max(0);
+                                }
+                            }
+                            "archer_schedule" => {
+                                if let Some(v) = crate::systems::remote::parse_work_schedule(val) {
+                                    policy.0.archer_schedule = v;
+                                }
+                            }
+                            "farmer_schedule" => {
+                                if let Some(v) = crate::systems::remote::parse_work_schedule(val) {
+                                    policy.0.farmer_schedule = v;
+                                }
+                            }
+                            "archer_off_duty" => {
+                                if let Some(v) = crate::systems::remote::parse_off_duty(val) {
+                                    policy.0.archer_off_duty = v;
+                                }
+                            }
+                            "farmer_off_duty" => {
+                                if let Some(v) = crate::systems::remote::parse_off_duty(val) {
+                                    policy.0.farmer_off_duty = v;
+                                }
+                            }
                             _ => {}
                         }
                     }
@@ -764,31 +794,57 @@ fn execute_actions(
             }
             "squad_target" => {
                 let squad_idx = p.get("squad").and_then(|s| s.parse::<usize>().ok());
-                let x = p
-                    .get("x")
-                    .and_then(|s| s.parse::<f32>().ok())
-                    .unwrap_or(0.0);
-                let y = p
-                    .get("y")
-                    .and_then(|s| s.parse::<f32>().ok())
-                    .unwrap_or(0.0);
+                let x = p.get("x").and_then(|s| s.parse::<f32>().ok());
+                let y = p.get("y").and_then(|s| s.parse::<f32>().ok());
                 if let Some(si) = squad_idx {
                     let owned = write.squad_state.squads.get(si).map(|sq| match sq.owner {
                         SquadOwner::Player => 0,
                         SquadOwner::Town(tdi) => tdi,
                     } == town).unwrap_or(false);
                     if owned {
-                        let target = bevy::math::Vec2::new(x, y);
-                        write.squad_state.squads[si].target = Some(target);
+                        let new_target = match (x, y) {
+                            (Some(tx), Some(ty)) => Some(bevy::math::Vec2::new(tx, ty)),
+                            _ => None,
+                        };
+                        write.squad_state.squads[si].target = new_target;
+                        let msg = if new_target.is_some() {
+                            format!("[{}] sent squad {} to attack", town_name, si)
+                        } else {
+                            format!("[{}] cleared squad {} target", town_name, si)
+                        };
                         write.combat_log.push_at(
                             CombatEventKind::Llm,
                             faction,
                             day,
                             hour,
                             minute,
-                            format!("[{}] sent squad {} to attack", town_name, si),
-                            Some(target),
+                            msg,
+                            new_target,
                         );
+                    }
+                }
+            }
+            "squad" => {
+                let squad_idx = p.get("squad").and_then(|s| s.parse::<usize>().ok());
+                if let Some(si) = squad_idx {
+                    let owned = write.squad_state.squads.get(si).map(|sq| match sq.owner {
+                        SquadOwner::Player => 0,
+                        SquadOwner::Town(tdi) => tdi,
+                    } == town).unwrap_or(false);
+                    if owned {
+                        if let Some(Ok(v)) = p.get("patrol_enabled").map(|s| s.parse::<bool>()) {
+                            write.squad_state.squads[si].patrol_enabled = v;
+                        }
+                        if let Some(Ok(v)) = p.get("rest_when_tired").map(|s| s.parse::<bool>()) {
+                            write.squad_state.squads[si].rest_when_tired = v;
+                        }
+                        if let Some(Ok(v)) = p.get("hold_fire").map(|s| s.parse::<bool>()) {
+                            write.squad_state.squads[si].hold_fire = v;
+                        }
+                        if let Some(Ok(v)) = p.get("loot_threshold").map(|s| s.parse::<usize>()) {
+                            write.squad_state.squads[si].loot_threshold =
+                                v.clamp(1, crate::resources::MAX_LOOT_THRESHOLD);
+                        }
                     }
                 }
             }

--- a/rust/src/systems/remote.rs
+++ b/rust/src/systems/remote.rs
@@ -20,6 +20,24 @@ use crate::resources::*;
 use crate::systemparams::WorldState;
 use crate::world::{BuildingKind, WorldData};
 
+pub fn parse_work_schedule(s: &str) -> Option<WorkSchedule> {
+    match s {
+        "Both" | "both" => Some(WorkSchedule::Both),
+        "DayOnly" | "day_only" | "day" => Some(WorkSchedule::DayOnly),
+        "NightOnly" | "night_only" | "night" => Some(WorkSchedule::NightOnly),
+        _ => None,
+    }
+}
+
+pub fn parse_off_duty(s: &str) -> Option<OffDutyBehavior> {
+    match s {
+        "GoToBed" | "go_to_bed" | "bed" => Some(OffDutyBehavior::GoToBed),
+        "StayAtFountain" | "stay_at_fountain" | "fountain" => Some(OffDutyBehavior::StayAtFountain),
+        "WanderTown" | "wander_town" | "wander" => Some(OffDutyBehavior::WanderTown),
+        _ => None,
+    }
+}
+
 fn queue_llm_log(world: &mut World, town: usize, message: String, location: Option<Vec2>) {
     let gt = world.resource::<GameTime>();
     let (day, hour, minute) = (gt.day(), gt.hour(), gt.minute());
@@ -560,6 +578,18 @@ struct PolicyParams {
     recovery_hp: Option<f32>,
     #[serde(default)]
     mining_radius: Option<f32>,
+    #[serde(default)]
+    reserve_food: Option<i32>,
+    #[serde(default)]
+    reserve_gold: Option<i32>,
+    #[serde(default)]
+    archer_schedule: Option<String>,
+    #[serde(default)]
+    farmer_schedule: Option<String>,
+    #[serde(default)]
+    archer_off_duty: Option<String>,
+    #[serde(default)]
+    farmer_off_duty: Option<String>,
 }
 
 pub fn policy_handler(In(params): In<Option<Value>>, world: &mut World) -> BrpResult {
@@ -638,6 +668,52 @@ pub fn policy_handler(In(params): In<Option<Value>>, world: &mut World) -> BrpRe
             }
             policy.mining_radius = v;
         }
+        if let Some(v) = p.reserve_food {
+            let v = v.max(0);
+            if v != policy.reserve_food {
+                parts.push(format!("reserve_food={v}"));
+            }
+            policy.reserve_food = v;
+        }
+        if let Some(v) = p.reserve_gold {
+            let v = v.max(0);
+            if v != policy.reserve_gold {
+                parts.push(format!("reserve_gold={v}"));
+            }
+            policy.reserve_gold = v;
+        }
+        if let Some(ref s) = p.archer_schedule {
+            if let Some(v) = parse_work_schedule(s) {
+                if v != policy.archer_schedule {
+                    parts.push(format!("archer_schedule={s}"));
+                }
+                policy.archer_schedule = v;
+            }
+        }
+        if let Some(ref s) = p.farmer_schedule {
+            if let Some(v) = parse_work_schedule(s) {
+                if v != policy.farmer_schedule {
+                    parts.push(format!("farmer_schedule={s}"));
+                }
+                policy.farmer_schedule = v;
+            }
+        }
+        if let Some(ref s) = p.archer_off_duty {
+            if let Some(v) = parse_off_duty(s) {
+                if v != policy.archer_off_duty {
+                    parts.push(format!("archer_off_duty={s}"));
+                }
+                policy.archer_off_duty = v;
+            }
+        }
+        if let Some(ref s) = p.farmer_off_duty {
+            if let Some(v) = parse_off_duty(s) {
+                if v != policy.farmer_off_duty {
+                    parts.push(format!("farmer_off_duty={s}"));
+                }
+                policy.farmer_off_duty = v;
+            }
+        }
         parts
     };
     if !parts.is_empty() {
@@ -680,8 +756,10 @@ pub fn time_handler(In(params): In<Option<Value>>, world: &mut World) -> BrpResu
 #[derive(Deserialize)]
 struct SquadTargetParams {
     squad: usize,
-    x: f32,
-    y: f32,
+    #[serde(default)]
+    x: Option<f32>,
+    #[serde(default)]
+    y: Option<f32>,
 }
 
 pub fn squad_target_handler(In(params): In<Option<Value>>, world: &mut World) -> BrpResult {
@@ -702,21 +780,37 @@ pub fn squad_target_handler(In(params): In<Option<Value>>, world: &mut World) ->
         check_town_allowed(world, town)?;
     }
 
-    queue_llm_log(
-        world,
-        town,
-        format!("squad {} target ({:.0},{:.0})", p.squad, p.x, p.y),
-        Some(Vec2::new(p.x, p.y)),
-    );
+    let new_target = match (p.x, p.y) {
+        (Some(x), Some(y)) => Some(Vec2::new(x, y)),
+        _ => None, // null/missing x or y = clear target
+    };
+
+    if let Some(t) = new_target {
+        queue_llm_log(
+            world,
+            town,
+            format!("squad {} target ({:.0},{:.0})", p.squad, t.x, t.y),
+            Some(t),
+        );
+    } else {
+        queue_llm_log(
+            world,
+            town,
+            format!("squad {} target cleared", p.squad),
+            None,
+        );
+    }
 
     let mut state = world.resource_mut::<SquadState>();
     let squad = state
         .squads
         .get_mut(p.squad)
         .ok_or_else(|| brp_err(format!("squad {} out of range", p.squad)))?;
-    squad.target = Some(Vec2::new(p.x, p.y));
+    squad.target = new_target;
 
-    toon_ok(json!({"status": "ok", "squad": p.squad, "target_x": p.x, "target_y": p.y}))
+    toon_ok(
+        json!({"status": "ok", "squad": p.squad, "target": new_target.map(|t| json!({"x": t.x, "y": t.y}))}),
+    )
 }
 
 // --- endless/ai_manager -----------------------------------------------------
@@ -816,6 +910,288 @@ pub fn ai_manager_handler(In(params): In<Option<Value>>, world: &mut World) -> B
         "personality": player.personality.name(),
         "road_style": format!("{:?}", player.road_style),
     }))
+}
+
+// --- endless/squad -----------------------------------------------------------
+
+#[derive(Deserialize)]
+struct SquadParams {
+    squad: usize,
+    #[serde(default)]
+    patrol_enabled: Option<bool>,
+    #[serde(default)]
+    rest_when_tired: Option<bool>,
+    #[serde(default)]
+    hold_fire: Option<bool>,
+    #[serde(default)]
+    loot_threshold: Option<usize>,
+}
+
+pub fn squad_handler(In(params): In<Option<Value>>, world: &mut World) -> BrpResult {
+    let p: SquadParams = parse_some(params)?;
+
+    let town;
+    {
+        let state = world.resource::<SquadState>();
+        let squad = state
+            .squads
+            .get(p.squad)
+            .ok_or_else(|| brp_err(format!("squad {} out of range", p.squad)))?;
+        town = match squad.owner {
+            SquadOwner::Player => 0,
+            SquadOwner::Town(tdi) => tdi,
+        };
+        check_town_allowed(world, town)?;
+    }
+
+    let parts;
+    {
+        let mut state = world.resource_mut::<SquadState>();
+        let squad = state
+            .squads
+            .get_mut(p.squad)
+            .ok_or_else(|| brp_err(format!("squad {} out of range", p.squad)))?;
+
+        let mut changed = Vec::new();
+        if let Some(v) = p.patrol_enabled {
+            if v != squad.patrol_enabled {
+                changed.push(format!("patrol_enabled={v}"));
+            }
+            squad.patrol_enabled = v;
+        }
+        if let Some(v) = p.rest_when_tired {
+            if v != squad.rest_when_tired {
+                changed.push(format!("rest_when_tired={v}"));
+            }
+            squad.rest_when_tired = v;
+        }
+        if let Some(v) = p.hold_fire {
+            if v != squad.hold_fire {
+                changed.push(format!("hold_fire={v}"));
+            }
+            squad.hold_fire = v;
+        }
+        if let Some(v) = p.loot_threshold {
+            let v = v.clamp(1, crate::resources::MAX_LOOT_THRESHOLD);
+            if v != squad.loot_threshold {
+                changed.push(format!("loot_threshold={v}"));
+            }
+            squad.loot_threshold = v;
+        }
+        parts = changed;
+    }
+
+    if !parts.is_empty() {
+        queue_llm_log(
+            world,
+            town,
+            format!("squad {} settings: {}", p.squad, parts.join(", ")),
+            None,
+        );
+    }
+
+    toon_ok(json!({"status": "ok", "squad": p.squad}))
+}
+
+// --- endless/squad_recruit ---------------------------------------------------
+
+#[derive(Deserialize)]
+struct SquadRecruitParams {
+    squad: usize,
+    job: String,
+    #[serde(default = "default_recruit_count")]
+    count: usize,
+}
+
+fn default_recruit_count() -> usize {
+    1
+}
+
+pub fn squad_recruit_handler(In(params): In<Option<Value>>, world: &mut World) -> BrpResult {
+    let p: SquadRecruitParams = parse_some(params)?;
+
+    let town;
+    let target_job;
+    {
+        let state = world.resource::<SquadState>();
+        let squad = state
+            .squads
+            .get(p.squad)
+            .ok_or_else(|| brp_err(format!("squad {} out of range", p.squad)))?;
+        town = match squad.owner {
+            SquadOwner::Player => 0,
+            SquadOwner::Town(tdi) => tdi,
+        };
+        check_town_allowed(world, town)?;
+
+        target_job = parse_job(&p.job).ok_or_else(|| brp_err(format!("unknown job: {}", p.job)))?;
+        if !target_job.is_military() {
+            return Err(brp_err(format!("{} is not a military job", p.job)));
+        }
+    }
+
+    // Find unassigned NPCs of this job in this town and assign to squad
+    let entity_map = world.resource::<EntityMap>();
+    let town_i32 = town as i32;
+    let mut candidates: Vec<Entity> = Vec::new();
+    for npc in entity_map.iter_npcs() {
+        if npc.job == target_job && npc.town_idx == town_i32 {
+            candidates.push(npc.entity);
+        }
+    }
+
+    // Filter to those not already in this squad
+    let state = world.resource::<SquadState>();
+    let existing_members: Vec<Entity> = state
+        .squads
+        .get(p.squad)
+        .map(|s| s.members.clone())
+        .unwrap_or_default();
+    candidates.retain(|e| !existing_members.contains(e));
+
+    let to_recruit = candidates.into_iter().take(p.count).collect::<Vec<_>>();
+    let recruited = to_recruit.len();
+
+    // Assign SquadId component and add to squad members
+    {
+        let mut state = world.resource_mut::<SquadState>();
+        let squad = state
+            .squads
+            .get_mut(p.squad)
+            .ok_or_else(|| brp_err(format!("squad {} out of range", p.squad)))?;
+        for &entity in &to_recruit {
+            if !squad.members.contains(&entity) {
+                squad.members.push(entity);
+            }
+        }
+    }
+
+    for &entity in &to_recruit {
+        if let Some(mut sid) = world.get_mut::<SquadId>(entity) {
+            sid.0 = p.squad as i32;
+        }
+    }
+
+    queue_llm_log(
+        world,
+        town,
+        format!("squad {} recruited {} {}", p.squad, recruited, p.job,),
+        None,
+    );
+
+    toon_ok(json!({"status": "ok", "squad": p.squad, "recruited": recruited}))
+}
+
+// --- endless/squad_dismiss ---------------------------------------------------
+
+#[derive(Deserialize)]
+struct SquadDismissParams {
+    squad: usize,
+    #[serde(default)]
+    job: Option<String>,
+    #[serde(default = "default_recruit_count")]
+    count: usize,
+}
+
+pub fn squad_dismiss_handler(In(params): In<Option<Value>>, world: &mut World) -> BrpResult {
+    let p: SquadDismissParams = parse_some(params)?;
+
+    let town;
+    {
+        let state = world.resource::<SquadState>();
+        let squad = state
+            .squads
+            .get(p.squad)
+            .ok_or_else(|| brp_err(format!("squad {} out of range", p.squad)))?;
+        town = match squad.owner {
+            SquadOwner::Player => 0,
+            SquadOwner::Town(tdi) => tdi,
+        };
+        check_town_allowed(world, town)?;
+    }
+
+    let target_job = p.job.as_ref().and_then(|s| parse_job(s));
+
+    // Collect member jobs before mutating squad state (avoids borrow conflict)
+    let members: Vec<(Entity, Option<Job>)>;
+    {
+        let state = world.resource::<SquadState>();
+        let squad = state
+            .squads
+            .get(p.squad)
+            .ok_or_else(|| brp_err(format!("squad {} out of range", p.squad)))?;
+        members = squad
+            .members
+            .iter()
+            .map(|&e| (e, world.get::<Job>(e).copied()))
+            .collect();
+    }
+
+    // Remove members from squad, optionally filtered by job
+    let mut dismissed_entities: Vec<Entity> = Vec::new();
+    let mut remaining = Vec::new();
+    let mut dismissed = 0usize;
+    for (entity, job) in &members {
+        if dismissed >= p.count {
+            remaining.push(*entity);
+            continue;
+        }
+        let matches = target_job
+            .map(|tj| job.map(|j| j == tj).unwrap_or(false))
+            .unwrap_or(true);
+        if matches {
+            dismissed_entities.push(*entity);
+            dismissed += 1;
+        } else {
+            remaining.push(*entity);
+        }
+    }
+    {
+        let mut state = world.resource_mut::<SquadState>();
+        let squad = state
+            .squads
+            .get_mut(p.squad)
+            .ok_or_else(|| brp_err(format!("squad {} out of range", p.squad)))?;
+        squad.members = remaining;
+    }
+
+    // Reset SquadId to 0 (default/unassigned)
+    for &entity in &dismissed_entities {
+        if let Some(mut sid) = world.get_mut::<SquadId>(entity) {
+            sid.0 = 0;
+        }
+    }
+
+    let dismissed_count = dismissed_entities.len();
+    queue_llm_log(
+        world,
+        town,
+        format!(
+            "squad {} dismissed {} {}",
+            p.squad,
+            dismissed_count,
+            p.job.as_deref().unwrap_or("members"),
+        ),
+        None,
+    );
+
+    toon_ok(json!({"status": "ok", "squad": p.squad, "dismissed": dismissed_count}))
+}
+
+fn parse_job(s: &str) -> Option<Job> {
+    match s {
+        "Farmer" | "farmer" => Some(Job::Farmer),
+        "Archer" | "archer" => Some(Job::Archer),
+        "Raider" | "raider" => Some(Job::Raider),
+        "Fighter" | "fighter" => Some(Job::Fighter),
+        "Miner" | "miner" => Some(Job::Miner),
+        "Crossbow" | "crossbow" => Some(Job::Crossbow),
+        "Boat" | "boat" => Some(Job::Boat),
+        "Woodcutter" | "woodcutter" => Some(Job::Woodcutter),
+        "Quarrier" | "quarrier" => Some(Job::Quarrier),
+        "Mason" | "mason" => Some(Job::Mason),
+        _ => None,
+    }
 }
 
 // --- endless/chat ------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add missing policy fields to `endless/policy` and LLM `policy` action: `reserve_food`, `reserve_gold`, `archer_schedule`, `farmer_schedule`, `archer_off_duty`, `farmer_off_duty`
- Add `endless/squad` endpoint + LLM `squad` action for squad settings: `patrol_enabled`, `rest_when_tired`, `hold_fire`, `loot_threshold`
- Add `endless/squad_recruit` and `endless/squad_dismiss` BRP endpoints for moving NPCs between squads
- Make `endless/squad_target` support clearing (omit x/y = clear target), also in LLM `squad_target`
- Update `docs/brp.md` and `docs/control-parity.md` to reflect closed gaps

Closes #69

## Test plan
- [x] cargo clippy --release -- -D warnings clean
- [x] cargo test 284 passed
- [ ] verify policy fields via BRP curl (in-game)
- [ ] verify squad settings via BRP curl (in-game)
- [ ] verify squad recruit/dismiss via BRP curl (in-game)
- [ ] verify clear squad target via BRP curl (in-game)