### PR TITLE
feature: farm mode toggle (crops/cows) with day/night and food mechanics

### DIFF
--- a/rust/src/components.rs
+++ b/rust/src/components.rs
@@ -686,6 +686,19 @@ pub struct FarmReadyMarker {
 // BUILDING STATE COMPONENTS (CRD pattern: runtime state on ECS entities)
 // ============================================================================
 
+/// Farm production mode: crops (daytime-only, farmer-tended) or cows (autonomous, food cost).
+#[derive(Clone, Copy, Default, PartialEq, Eq, Debug, Reflect)]
+pub enum FarmMode {
+    #[default]
+    Crops,
+    Cows,
+}
+
+/// Per-farm mode component. Defaults to Crops.
+#[derive(Component, Clone, Copy, Default, Reflect)]
+#[reflect(Component)]
+pub struct FarmModeComp(pub FarmMode);
+
 /// Production cycle for worksites (farms grow food, mines extract gold).
 /// Replaces BuildingInstance.growth_ready/growth_progress.
 /// Occupants tracked by EntityMap (worksite claim counter).
@@ -699,13 +712,21 @@ pub struct ProductionState {
 impl ProductionState {
     /// Harvest a Ready worksite. Resets to Growing, returns yield.
     pub fn harvest(&mut self, kind: crate::world::BuildingKind) -> i32 {
+        self.harvest_with_mode(kind, FarmMode::Crops)
+    }
+
+    /// Harvest with farm mode awareness. Cows yield more per cycle.
+    pub fn harvest_with_mode(&mut self, kind: crate::world::BuildingKind, mode: FarmMode) -> i32 {
         if !self.ready {
             return 0;
         }
         self.ready = false;
         self.progress = 0.0;
         match kind {
-            crate::world::BuildingKind::Farm => 1,
+            crate::world::BuildingKind::Farm => match mode {
+                FarmMode::Crops => 1,
+                FarmMode::Cows => crate::constants::COW_HARVEST_YIELD,
+            },
             crate::world::BuildingKind::GoldMine => crate::constants::MINE_EXTRACT_PER_CYCLE,
             crate::world::BuildingKind::TreeNode => 1,
             crate::world::BuildingKind::RockNode => 1,

--- a/rust/src/constants/mod.rs
+++ b/rust/src/constants/mod.rs
@@ -140,6 +140,15 @@ pub const FARM_TENDED_GROWTH_RATE: f32 = 0.25;
 // Passive only: ~12 hours to grow
 // With farmer: ~4 hours to grow
 
+/// Cow growth rate (no farmer needed, grows day and night).
+pub const COW_GROWTH_RATE: f32 = 0.12;
+
+/// Food consumed per game hour while cows are growing (net cost).
+pub const COW_FOOD_COST_PER_HOUR: i32 = 1;
+
+/// Food produced per cow harvest cycle (higher than crops to offset cost).
+pub const COW_HARVEST_YIELD: i32 = 3;
+
 /// Maximum farms for item MultiMesh slot allocation.
 pub const MAX_FARMS: usize = 500;
 

--- a/rust/src/save.rs
+++ b/rust/src/save.rs
@@ -31,6 +31,7 @@ pub struct BuildingStateSnapshot {
     pub under_construction: f32,
     pub npc_slot: Option<usize>,
     pub respawn_timer: f32,
+    pub farm_mode: u8,
 }
 
 // ============================================================================
@@ -307,6 +308,9 @@ pub struct FarmGrowthSave {
     pub progress: f32,
     #[serde(default)]
     pub under_construction: f32,
+    /// 0=Crops (default), 1=Cows
+    #[serde(default)]
+    pub farm_mode: u8,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -914,6 +918,7 @@ pub fn collect_save_data(
                 },
                 progress: bs.map_or(0.0, |s| s.production_progress),
                 under_construction: bs.map_or(0.0, |s| s.under_construction),
+                farm_mode: bs.map_or(0, |s| s.farm_mode),
             }
         })
         .collect();
@@ -1041,6 +1046,7 @@ pub fn collect_save_data(
                     },
                     progress: bs.map_or(0.0, |s| s.production_progress),
                     under_construction: bs.map_or(0.0, |s| s.under_construction),
+                    farm_mode: 0,
                 }
             })
             .collect(),
@@ -1715,12 +1721,13 @@ fn collect_building_state_snapshot(
             Option<&ProductionState>,
             Option<&ConstructionProgress>,
             Option<&SpawnerState>,
+            Option<&FarmModeComp>,
         ),
         With<Building>,
     >,
 ) -> std::collections::HashMap<usize, BuildingStateSnapshot> {
     let mut map = std::collections::HashMap::new();
-    for (gpu_slot, wp, mc, wl, ts, ps, cp, sp) in q.iter() {
+    for (gpu_slot, wp, mc, wl, ts, ps, cp, sp, fm) in q.iter() {
         let mut s = BuildingStateSnapshot::default();
         if let Some(wp) = wp {
             s.patrol_order = wp.0;
@@ -1748,6 +1755,12 @@ fn collect_building_state_snapshot(
         if let Some(sp) = sp {
             s.npc_slot = sp.npc_slot;
             s.respawn_timer = sp.respawn_timer;
+        }
+        if let Some(fm) = fm {
+            s.farm_mode = match fm.0 {
+                FarmMode::Crops => 0,
+                FarmMode::Cows => 1,
+            };
         }
         map.insert(gpu_slot.0, s);
     }
@@ -1948,6 +1961,12 @@ pub fn restore_growth_from_save(save: &SaveData, entity_map: &EntityMap, command
                 commands
                     .entity(entity)
                     .insert(ConstructionProgress(fg.under_construction));
+                let mode = if fg.farm_mode == 1 {
+                    FarmMode::Cows
+                } else {
+                    FarmMode::Crops
+                };
+                commands.entity(entity).insert(FarmModeComp(mode));
             }
         }
     }
@@ -2016,6 +2035,7 @@ pub fn save_game_system(
             Option<&ProductionState>,
             Option<&ConstructionProgress>,
             Option<&SpawnerState>,
+            Option<&FarmModeComp>,
         ),
         With<Building>,
     >,
@@ -2137,6 +2157,7 @@ pub fn autosave_system(
             Option<&ProductionState>,
             Option<&ConstructionProgress>,
             Option<&SpawnerState>,
+            Option<&FarmModeComp>,
         ),
         With<Building>,
     >,

--- a/rust/src/systems/decision/mod.rs
+++ b/rust/src/systems/decision/mod.rs
@@ -246,6 +246,7 @@ pub fn decision_system(
     >,
     miner_cfg_q: Query<&MinerHomeConfig>,
     mut production_q: Query<&mut ProductionState>,
+    farm_mode_q: Query<&FarmModeComp>,
     mut building_health_q: Query<&mut Health, With<Building>>,
 ) {
     if game_time.is_paused() {
@@ -621,12 +622,16 @@ pub fn decision_system(
                                     );
                                 } else if entity_map.get_instance(farm_slot).is_some() {
                                     // Check if farm ready for harvest via ECS ProductionState
-                                    let harvest = entity_map
-                                        .entities
-                                        .get(&farm_slot)
-                                        .and_then(|&e| production_q.get_mut(e).ok())
+                                    let farm_entity_opt =
+                                        entity_map.entities.get(&farm_slot).copied();
+                                    let harvest = farm_entity_opt
+                                        .and_then(|e| production_q.get_mut(e).ok())
                                         .and_then(|mut ps| {
-                                            let food = ps.harvest(BuildingKind::Farm);
+                                            let mode = farm_entity_opt
+                                                .and_then(|e| farm_mode_q.get(e).ok())
+                                                .map_or(FarmMode::Crops, |m| m.0);
+                                            let food =
+                                                ps.harvest_with_mode(BuildingKind::Farm, mode);
                                             if food > 0 {
                                                 let pos = entity_map
                                                     .get_instance(farm_slot)
@@ -798,12 +803,16 @@ pub fn decision_system(
                             });
 
                             if let Some(fp) = ready_farm_pos {
-                                let food = entity_map
+                                let farm_e = entity_map
                                     .slot_at_position(fp)
-                                    .and_then(|slot| entity_map.entities.get(&slot).copied())
+                                    .and_then(|slot| entity_map.entities.get(&slot).copied());
+                                let food = farm_e
                                     .and_then(|e| production_q.get_mut(e).ok())
                                     .map(|mut ps| {
-                                        let f = ps.harvest(BuildingKind::Farm);
+                                        let mode = farm_e
+                                            .and_then(|e| farm_mode_q.get(e).ok())
+                                            .map_or(FarmMode::Crops, |m| m.0);
+                                        let f = ps.harvest_with_mode(BuildingKind::Farm, mode);
                                         if f > 0 {
                                             combat_log.write(CombatLogMsg {
                                                 kind: CombatEventKind::Harvest,
@@ -1985,7 +1994,10 @@ pub fn decision_system(
                         let ws_pos = entity_map
                             .get_instance(slot)
                             .map_or(Vec2::ZERO, |i| i.position);
-                        let base_yield = ps.harvest(kind);
+                        let mode = ws_entity
+                            .and_then(|e| farm_mode_q.get(e).ok())
+                            .map_or(FarmMode::Crops, |m| m.0);
+                        let base_yield = ps.harvest_with_mode(kind, mode);
                         if base_yield > 0 {
                             combat_log.write(CombatLogMsg {
                                 kind: CombatEventKind::Harvest,

--- a/rust/src/systems/economy/mod.rs
+++ b/rust/src/systems/economy/mod.rs
@@ -8,9 +8,10 @@ use std::collections::{HashMap, HashSet};
 use crate::components::*;
 use crate::constants::UpgradeStatKind;
 use crate::constants::{
-    BOAT_SPEED, ENDLESS_RESPAWN_DELAY_HOURS, FARM_BASE_GROWTH_RATE, FARM_TENDED_GROWTH_RATE,
-    MIGRATION_BASE_SIZE, RAIDER_FORAGE_RATE, RAIDER_SETTLE_RADIUS, SPAWNER_RESPAWN_HOURS,
-    STARVING_HP_CAP, STARVING_SPEED_MULT, TOWN_GRID_SPACING,
+    BOAT_SPEED, COW_FOOD_COST_PER_HOUR, COW_GROWTH_RATE, ENDLESS_RESPAWN_DELAY_HOURS,
+    FARM_BASE_GROWTH_RATE, FARM_TENDED_GROWTH_RATE, MIGRATION_BASE_SIZE, RAIDER_FORAGE_RATE,
+    RAIDER_SETTLE_RADIUS, SPAWNER_RESPAWN_HOURS, STARVING_HP_CAP, STARVING_SPEED_MULT,
+    TOWN_GRID_SPACING,
 };
 use crate::messages::{CombatLogMsg, GpuUpdate, GpuUpdateMsg, SpawnNpcMsg};
 use crate::resources::*;
@@ -136,13 +137,14 @@ pub fn construction_tick_system(
 // ============================================================================
 
 /// Unified production system for farms and mines.
-/// - Farms: passive + tended rates (unchanged). Upgrade-scaled by FarmYield.
+/// - Farms (Crops): daytime-only, passive + tended rates. Upgrade-scaled by FarmYield.
+/// - Farms (Cows): day+night, autonomous growth, consumes food per hour.
 /// - Mines: tended-only (MINE_TENDED_GROWTH_RATE). Zero production when unoccupied.
 pub fn growth_system(
     time: Res<Time>,
     game_time: Res<GameTime>,
     entity_map: Res<EntityMap>,
-    town_access: crate::systemparams::TownAccess,
+    mut town_access: crate::systemparams::TownAccess,
     mut production_q: Query<(
         &GpuSlot,
         &Building,
@@ -150,6 +152,7 @@ pub fn growth_system(
         &Position,
         &ConstructionProgress,
         &mut ProductionState,
+        Option<&FarmModeComp>,
     )>,
     world_data: Res<crate::world::WorldData>,
 ) {
@@ -158,6 +161,7 @@ pub fn growth_system(
     }
 
     let hours_elapsed = game_time.delta(&time) / game_time.seconds_per_hour;
+    let is_daytime = game_time.is_daytime();
 
     // Precompute per-town farm yield multiplier
     let max_towns = world_data.towns.len();
@@ -167,26 +171,58 @@ pub fn growth_system(
         farm_mults.push(UPGRADES.stat_mult(&levels, "Farmer", UpgradeStatKind::Yield));
     }
 
-    for (gpu_slot, building, town_id, pos, construction, mut production) in &mut production_q {
+    // Track food costs per town from cow farms (batch deduct after loop)
+    let mut cow_food_costs: Vec<(i32, i32)> = Vec::new();
+
+    for (gpu_slot, building, town_id, pos, construction, mut production, farm_mode) in
+        &mut production_q
+    {
         if pos.x < -9000.0 || production.ready || construction.0 > 0.0 {
             continue;
         }
         let slot = gpu_slot.0;
         match building.kind {
             BuildingKind::Farm => {
-                let is_tended = entity_map.occupant_count(slot) >= 1;
-                let base_rate = if is_tended {
-                    FARM_TENDED_GROWTH_RATE
-                } else {
-                    FARM_BASE_GROWTH_RATE
-                };
-                let mult = farm_mults.get(town_id.0 as usize).copied().unwrap_or(1.0);
-                let growth_rate = base_rate * mult;
-                if growth_rate > 0.0 {
-                    production.progress += growth_rate * hours_elapsed;
-                    if production.progress >= 1.0 {
-                        production.ready = true;
-                        production.progress = 1.0;
+                let mode = farm_mode.map_or(FarmMode::Crops, |m| m.0);
+                match mode {
+                    FarmMode::Crops => {
+                        // Crops only grow during daytime
+                        if !is_daytime {
+                            continue;
+                        }
+                        let is_tended = entity_map.occupant_count(slot) >= 1;
+                        let base_rate = if is_tended {
+                            FARM_TENDED_GROWTH_RATE
+                        } else {
+                            FARM_BASE_GROWTH_RATE
+                        };
+                        let mult = farm_mults.get(town_id.0 as usize).copied().unwrap_or(1.0);
+                        let growth_rate = base_rate * mult;
+                        if growth_rate > 0.0 {
+                            production.progress += growth_rate * hours_elapsed;
+                            if production.progress >= 1.0 {
+                                production.ready = true;
+                                production.progress = 1.0;
+                            }
+                        }
+                    }
+                    FarmMode::Cows => {
+                        // Cows grow day and night, no tending needed
+                        let mult = farm_mults.get(town_id.0 as usize).copied().unwrap_or(1.0);
+                        let growth_rate = COW_GROWTH_RATE * mult;
+                        if growth_rate > 0.0 {
+                            production.progress += growth_rate * hours_elapsed;
+                            // Track food cost for this cow farm
+                            let food_cost =
+                                (COW_FOOD_COST_PER_HOUR as f32 * hours_elapsed).ceil() as i32;
+                            if food_cost > 0 {
+                                cow_food_costs.push((town_id.0, food_cost));
+                            }
+                            if production.progress >= 1.0 {
+                                production.ready = true;
+                                production.progress = 1.0;
+                            }
+                        }
                     }
                 }
             }
@@ -207,6 +243,13 @@ pub fn growth_system(
                 }
             }
             _ => {}
+        }
+    }
+
+    // Batch-deduct cow food costs per town
+    for (town_idx, cost) in cow_food_costs {
+        if let Some(mut f) = town_access.food_mut(town_idx) {
+            f.0 = (f.0 - cost).max(0);
         }
     }
 }

--- a/rust/src/systems/economy/tests.rs
+++ b/rust/src/systems/economy/tests.rs
@@ -793,6 +793,107 @@ fn mine_grows_with_workers() {
     );
 }
 
+fn add_cow_farm(app: &mut App, slot: usize) {
+    let inst = test_building_instance(slot, BuildingKind::Farm, 0.0);
+    let entity = app
+        .world_mut()
+        .spawn((
+            GpuSlot(slot),
+            Building {
+                kind: BuildingKind::Farm,
+            },
+            TownId(0),
+            Position { x: 0.0, y: 0.0 },
+            ConstructionProgress(0.0),
+            ProductionState {
+                ready: false,
+                progress: 0.0,
+            },
+            FarmModeComp(FarmMode::Cows),
+        ))
+        .id();
+    let mut em = app.world_mut().resource_mut::<EntityMap>();
+    em.set_entity(slot, entity);
+    em.add_instance(inst);
+}
+
+#[test]
+fn crops_do_not_grow_at_night() {
+    let mut app = setup_growth_app();
+    // Set time to midnight (nighttime: hour outside 6..20)
+    app.world_mut().resource_mut::<GameTime>().total_seconds = 0.0;
+    app.world_mut().resource_mut::<GameTime>().start_hour = 0;
+    assert!(
+        !app.world().resource::<GameTime>().is_daytime(),
+        "should be nighttime"
+    );
+    add_farm(&mut app, 0, true);
+
+    app.update();
+    let entity = *app
+        .world()
+        .resource::<EntityMap>()
+        .entities
+        .get(&0)
+        .unwrap();
+    let ps = app.world().get::<ProductionState>(entity).unwrap();
+    assert!(
+        ps.progress < f32::EPSILON,
+        "crops should NOT grow at night: {}",
+        ps.progress
+    );
+}
+
+#[test]
+fn cows_grow_at_night() {
+    let mut app = setup_growth_app();
+    // Set time to midnight (nighttime)
+    app.world_mut().resource_mut::<GameTime>().total_seconds = 0.0;
+    app.world_mut().resource_mut::<GameTime>().start_hour = 0;
+    assert!(
+        !app.world().resource::<GameTime>().is_daytime(),
+        "should be nighttime"
+    );
+    add_cow_farm(&mut app, 0);
+
+    app.update();
+    let entity = *app
+        .world()
+        .resource::<EntityMap>()
+        .entities
+        .get(&0)
+        .unwrap();
+    let ps = app.world().get::<ProductionState>(entity).unwrap();
+    assert!(
+        ps.progress > 0.0,
+        "cows should grow at night: {}",
+        ps.progress
+    );
+}
+
+#[test]
+fn cows_consume_food() {
+    let mut app = setup_growth_app();
+    // Give the town some food
+    let town_entity = *app
+        .world()
+        .resource::<crate::resources::TownIndex>()
+        .0
+        .get(&0)
+        .unwrap();
+    app.world_mut().get_mut::<FoodStore>(town_entity).unwrap().0 = 100;
+
+    add_cow_farm(&mut app, 0);
+
+    // Run a few ticks
+    for _ in 0..5 {
+        app.update();
+    }
+
+    let food = app.world().get::<FoodStore>(town_entity).unwrap().0;
+    assert!(food < 100, "cow farm should consume food: {}", food);
+}
+
 // ========================================================================
 // merchant_tick_system tests
 // ========================================================================

--- a/rust/src/ui/game_hud.rs
+++ b/rust/src/ui/game_hud.rs
@@ -702,6 +702,7 @@ pub struct BuildingInspectorData<'w, 's> {
     pub spawner_q: Query<'w, 's, &'static SpawnerState, With<Building>>,
     pub wall_level_q: Query<'w, 's, &'static mut WallLevel, With<Building>>,
     pub waypoint_order_q: Query<'w, 's, &'static WaypointOrder, With<Building>>,
+    pub farm_mode_q: Query<'w, 's, &'static mut FarmModeComp, With<Building>>,
 }
 
 #[derive(SystemParam)]
@@ -2438,6 +2439,33 @@ fn building_inspector_content(
     if !is_constructing {
         match kind {
             BuildingKind::Farm => {
+                // Farm mode toggle
+                let current_mode = bld_entity
+                    .and_then(|e| bld.farm_mode_q.get(e).ok())
+                    .map_or(FarmMode::Crops, |m| m.0);
+                ui.horizontal(|ui| {
+                    ui.label("Mode:");
+                    let mut is_cows = current_mode == FarmMode::Cows;
+                    if ui.selectable_label(!is_cows, "Crops").clicked() && is_cows {
+                        is_cows = false;
+                    }
+                    if ui.selectable_label(is_cows, "Cows").clicked() && !is_cows {
+                        is_cows = true;
+                    }
+                    let new_mode = if is_cows {
+                        FarmMode::Cows
+                    } else {
+                        FarmMode::Crops
+                    };
+                    if new_mode != current_mode {
+                        if let Some(e) = bld_entity {
+                            if let Ok(mut fm) = bld.farm_mode_q.get_mut(e) {
+                                fm.0 = new_mode;
+                            }
+                        }
+                    }
+                });
+
                 if let Some(ps) = bld_entity.and_then(|e| bld.production_q.get(e).ok()) {
                     let state_name = if ps.ready {
                         "Ready to harvest"
@@ -2460,10 +2488,14 @@ fn building_inspector_content(
                         );
                     });
 
-                    let occupants = bld_slot
-                        .map(|s| bld.entity_map.occupant_count(s))
-                        .unwrap_or(0);
-                    ui.label(format!("Farmers: {}", occupants));
+                    if current_mode == FarmMode::Crops {
+                        let occupants = bld_slot
+                            .map(|s| bld.entity_map.occupant_count(s))
+                            .unwrap_or(0);
+                        ui.label(format!("Farmers: {}", occupants));
+                    } else {
+                        ui.label("Autonomous (no farmer needed)");
+                    }
                 }
             }
 

--- a/rust/src/world.rs
+++ b/rust/src/world.rs
@@ -751,6 +751,9 @@ pub fn place_building(
     if def.worksite.is_some() {
         ecmds.insert(ProductionState::default());
     }
+    if kind == BuildingKind::Farm {
+        ecmds.insert(crate::components::FarmModeComp::default());
+    }
     if def.spawner.is_some() {
         // Suppress spawner during construction (timer=-1), arm on completion (timer=0)
         let timer = if under_construction > 0.0 { -1.0 } else { 0.0 };


### PR DESCRIPTION
Closes #71

## Summary

- Add `FarmMode` enum (Crops/Cows) and `FarmModeComp` ECS component for per-farm mode
- **Crops**: now only grow during daytime (6am-8pm), tended/untended rates unchanged
- **Cows**: grow day and night autonomously (no farmer needed), consume food per hour, yield 3x per harvest
- UI toggle in building inspector when a farm is selected (Crops/Cows selectable labels)
- Save/load round-trips farm mode via `FarmGrowthSave.farm_mode` field (`#[serde(default)]` for old save compat)
- New constants: `COW_GROWTH_RATE` (0.12/hr), `COW_FOOD_COST_PER_HOUR` (1), `COW_HARVEST_YIELD` (3)

## Changes

- `components.rs`: add `FarmMode`, `FarmModeComp`, `harvest_with_mode()`
- `constants/mod.rs`: add cow growth/cost/yield constants
- `systems/economy/mod.rs`: gate crop growth on daytime, add cow growth path with food deduction
- `systems/decision/mod.rs`: use `harvest_with_mode()` at all 3 farm harvest call sites
- `ui/game_hud.rs`: add farm mode toggle in building inspector, `farm_mode_q` to `BuildingInspectorData`
- `world.rs`: attach `FarmModeComp::default()` on farm spawn
- `save.rs`: add `farm_mode` to `FarmGrowthSave` + `BuildingStateSnapshot`, save/load round-trip

## Tests

- `cargo clippy --release -- -D warnings` clean
- `cargo test` -- 287 passed, 0 failed
- 3 new tests: `crops_do_not_grow_at_night`, `cows_grow_at_night`, `cows_consume_food`