### PR TITLE
feat: entity sleeping for static buildings (trees, rocks)

### DIFF
--- a/rust/src/components.rs
+++ b/rust/src/components.rs
@@ -675,6 +675,12 @@ pub struct Building {
     pub kind: crate::world::BuildingKind,
 }
 
+/// Marker: entity is static and excluded from per-frame CPU building systems.
+/// Applied to density-spawned trees/rocks that never change state until an NPC
+/// claims them as a worksite (which removes Sleeping).
+#[derive(Component)]
+pub struct Sleeping;
+
 /// Marker: farm is visually Ready (food icon overlay).
 #[derive(Component, Reflect)]
 #[reflect(Component)]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -567,6 +567,7 @@ pub fn build_app(app: &mut App) {
                 (
                     construction_tick_system.before(growth_system),
                     growth_system,
+                    sync_sleeping_system,
                 ),
                 raider_forage_system,
                 spawner_respawn_system,

--- a/rust/src/systems/economy/mod.rs
+++ b/rust/src/systems/economy/mod.rs
@@ -92,13 +92,16 @@ pub fn game_time_system(time: Res<Time>, mut game_time: ResMut<GameTime>) {
 pub fn construction_tick_system(
     time: Res<Time>,
     game_time: Res<GameTime>,
-    mut buildings_q: Query<(
-        &GpuSlot,
-        &Building,
-        &mut ConstructionProgress,
-        &mut Health,
-        Option<&mut SpawnerState>,
-    )>,
+    mut buildings_q: Query<
+        (
+            &GpuSlot,
+            &Building,
+            &mut ConstructionProgress,
+            &mut Health,
+            Option<&mut SpawnerState>,
+        ),
+        Without<Sleeping>,
+    >,
     mut gpu_updates: MessageWriter<GpuUpdateMsg>,
 ) {
     if game_time.is_paused() {
@@ -145,15 +148,18 @@ pub fn growth_system(
     game_time: Res<GameTime>,
     entity_map: Res<EntityMap>,
     mut town_access: crate::systemparams::TownAccess,
-    mut production_q: Query<(
-        &GpuSlot,
-        &Building,
-        &TownId,
-        &Position,
-        &ConstructionProgress,
-        &mut ProductionState,
-        Option<&FarmModeComp>,
-    )>,
+    mut production_q: Query<
+        (
+            &GpuSlot,
+            &Building,
+            &TownId,
+            &Position,
+            &ConstructionProgress,
+            &mut ProductionState,
+            Option<&FarmModeComp>,
+        ),
+        Without<Sleeping>,
+    >,
     world_data: Res<crate::world::WorldData>,
 ) {
     if game_time.is_paused() {
@@ -250,6 +256,44 @@ pub fn growth_system(
     for (town_idx, cost) in cow_food_costs {
         if let Some(mut f) = town_access.food_mut(town_idx) {
             f.0 = (f.0 - cost).max(0);
+        }
+    }
+}
+
+// ============================================================================
+// SLEEPING SYNC SYSTEM (trees/rocks)
+// ============================================================================
+
+/// Sync `Sleeping` marker on density-spawned buildings based on occupancy.
+/// Remove `Sleeping` when an NPC occupies the worksite; re-add when vacant.
+pub fn sync_sleeping_system(
+    mut commands: Commands,
+    entity_map: Res<EntityMap>,
+    sleeping_q: Query<(Entity, &GpuSlot, &Building), With<Sleeping>>,
+    awake_q: Query<(Entity, &GpuSlot, &Building), Without<Sleeping>>,
+) {
+    // Wake: remove Sleeping when occupied
+    for (entity, gpu_slot, building) in &sleeping_q {
+        if !matches!(
+            building.kind,
+            BuildingKind::TreeNode | BuildingKind::RockNode
+        ) {
+            continue;
+        }
+        if entity_map.occupant_count(gpu_slot.0) > 0 {
+            commands.entity(entity).remove::<Sleeping>();
+        }
+    }
+    // Re-sleep: add Sleeping when no occupants
+    for (entity, gpu_slot, building) in &awake_q {
+        if !matches!(
+            building.kind,
+            BuildingKind::TreeNode | BuildingKind::RockNode
+        ) {
+            continue;
+        }
+        if entity_map.occupant_count(gpu_slot.0) == 0 {
+            commands.entity(entity).insert(Sleeping);
         }
     }
 }

--- a/rust/src/world.rs
+++ b/rust/src/world.rs
@@ -748,6 +748,9 @@ pub fn place_building(
         ConstructionProgress(under_construction),
     ));
     // Kind-specific state components
+    if matches!(kind, BuildingKind::TreeNode | BuildingKind::RockNode) && ctx.is_none() {
+        ecmds.insert(crate::components::Sleeping);
+    }
     if def.worksite.is_some() {
         ecmds.insert(ProductionState::default());
     }


### PR DESCRIPTION
## Summary
- Add `Sleeping` marker component for static buildings (trees, rocks)
- Trees/rocks spawn with `Sleeping` at world gen and load time
- `construction_tick_system` and `growth_system` filter `Without<Sleeping>` to skip static entities
- `sync_sleeping_system` manages wake/sleep based on worksite occupancy: removes `Sleeping` when an NPC occupies the worksite, re-adds when vacant
- GPU compute cost is already minimal for static buildings (shader early-exits for speed=0 non-towers), so GPU-side sleeping deferred as future optimization

Closes #75

## Test plan
- [x] cargo clippy --release -- -D warnings clean
- [x] cargo test 287 passed
- [ ] verify trees/rocks render correctly with Sleeping component
- [ ] verify woodcutter/quarrier can still harvest (wake on occupy, re-sleep on release)
- [ ] benchmark building systems before/after with realistic tree/rock counts