### PR TITLE
feat: cow farm visuals, farmer exclusion, and test (#71)

### DIFF
--- a/rust/src/npc_render.rs
+++ b/rust/src/npc_render.rs
@@ -763,21 +763,33 @@ fn build_overlay_instances(
         &crate::components::Building,
         &crate::components::ProductionState,
         &crate::components::ConstructionProgress,
+        Option<&crate::components::FarmModeComp>,
     )>,
 ) {
     overlay.0.clear();
 
-    for (pos, building, production, construction) in &production_q {
+    for (pos, building, production, construction, farm_mode) in &production_q {
         if pos.x < -9000.0 || construction.0 > 0.0 {
             continue;
         }
 
         match building.kind {
             crate::world::BuildingKind::Farm => {
-                let color = if production.ready {
-                    [1.0, 0.85, 0.0, 1.0]
+                let is_cow = farm_mode.is_some_and(|m| m.0 == crate::components::FarmMode::Cows);
+                let color = if is_cow {
+                    // Cows: brown tint (growing) / orange-gold (ready)
+                    if production.ready {
+                        [1.0, 0.65, 0.2, 1.0]
+                    } else {
+                        [0.65, 0.4, 0.2, 1.0]
+                    }
                 } else {
-                    [0.4, 0.8, 0.2, 1.0]
+                    // Crops: green (growing) / gold (ready)
+                    if production.ready {
+                        [1.0, 0.85, 0.0, 1.0]
+                    } else {
+                        [0.4, 0.8, 0.2, 1.0]
+                    }
                 };
                 overlay.0.push(InstanceData {
                     position: [pos.x, pos.y],

--- a/rust/src/systems/decision/mod.rs
+++ b/rust/src/systems/decision/mod.rs
@@ -277,6 +277,21 @@ pub fn decision_system(
     const COMBAT_BUCKET: usize = 16; // ~267ms at 60fps
     let combat_bucket = (COMBAT_BUCKET as f32 / speed_scale).max(1.0) as usize;
 
+    // Pre-build cow farm set for farmer targeting exclusion (cheap: only farm buildings)
+    let cow_farm_slots: std::collections::HashSet<usize> = entity_map
+        .iter_instances()
+        .filter(|inst| inst.kind == crate::world::BuildingKind::Farm)
+        .filter_map(|inst| {
+            let e = entity_map.entities.get(&inst.slot)?;
+            let fm = farm_mode_q.get(*e).ok()?;
+            if fm.0 == FarmMode::Cows {
+                Some(inst.slot)
+            } else {
+                None
+            }
+        })
+        .collect();
+
     for (entity, slot, job, town_id, faction) in decision_npc_q.iter() {
         let idx = slot.0;
 
@@ -2471,6 +2486,7 @@ pub fn decision_system(
                                 &entity_map,
                                 town_idx_i32 as u32,
                                 &empty_map,
+                                &cow_farm_slots,
                             )
                             .is_some()
                             {

--- a/rust/src/systems/economy/tests.rs
+++ b/rust/src/systems/economy/tests.rs
@@ -894,6 +894,49 @@ fn cows_consume_food() {
     assert!(food < 100, "cow farm should consume food: {}", food);
 }
 
+#[test]
+fn farmers_skip_cow_farms() {
+    // Verify that find_farm_target returns None when only cow farms are available.
+    let mut entity_map = EntityMap::default();
+    entity_map.init_spatial(2048.0); // init spatial grid for search
+    let slot = 0usize;
+    let pos = Vec2::new(100.0, 100.0);
+    let mut inst = test_building_instance(slot, BuildingKind::Farm, 0.0);
+    inst.position = pos;
+    let entity = Entity::from_raw_u32(0).unwrap();
+    entity_map.set_entity(slot, entity);
+    entity_map.add_instance(inst);
+
+    let production_map = std::collections::HashMap::new();
+    let mut cow_set = std::collections::HashSet::new();
+    cow_set.insert(slot);
+
+    // With cow set containing this slot, farmer should not target it
+    let result = crate::systems::work_targeting::find_farm_target(
+        pos,
+        &entity_map,
+        0,
+        &production_map,
+        &cow_set,
+    );
+    assert!(
+        result.is_none(),
+        "farmer should NOT target a cow farm, got {:?}",
+        result
+    );
+
+    // Without the cow filter, farmer should find it
+    let empty_set = std::collections::HashSet::new();
+    let result = crate::systems::work_targeting::find_farm_target(
+        pos,
+        &entity_map,
+        0,
+        &production_map,
+        &empty_set,
+    );
+    assert!(result.is_some(), "farmer SHOULD target a crop farm");
+}
+
 // ========================================================================
 // merchant_tick_system tests
 // ========================================================================

--- a/rust/src/systems/work_targeting.rs
+++ b/rust/src/systems/work_targeting.rs
@@ -21,6 +21,7 @@ pub fn resolve_work_targets(
     mut activity_q: Query<&mut crate::components::Activity>,
     mut path_queue: ResMut<PathRequestQueue>,
     production_q: Query<&ProductionState, With<Building>>,
+    farm_mode_q: Query<&FarmModeComp, With<Building>>,
 ) {
     let msgs: Vec<_> = intents.read().collect();
     if msgs.is_empty() {
@@ -37,6 +38,22 @@ pub fn resolve_work_targets(
             Some((inst.slot, (ps.ready, ps.progress)))
         })
         .collect();
+
+    // Pre-collect cow farm slots so farmers skip them during targeting.
+    let cow_farm_slots: std::collections::HashSet<usize> = entity_map
+        .iter_instances()
+        .filter(|inst| inst.kind == BuildingKind::Farm)
+        .filter_map(|inst| {
+            let entity = entity_map.entities.get(&inst.slot)?;
+            let fm = farm_mode_q.get(*entity).ok()?;
+            if fm.0 == FarmMode::Cows {
+                Some(inst.slot)
+            } else {
+                None
+            }
+        })
+        .collect();
+
     for WorkIntentMsg(intent) in msgs {
         match intent {
             WorkIntent::Release { entity, worksite } => {
@@ -60,6 +77,7 @@ pub fn resolve_work_targets(
                     &mut activity_q,
                     &mut path_queue,
                     &production_map,
+                    &cow_farm_slots,
                 );
             }
             WorkIntent::Retarget {
@@ -79,6 +97,7 @@ pub fn resolve_work_targets(
                     &mut activity_q,
                     &mut path_queue,
                     &production_map,
+                    &cow_farm_slots,
                 );
             }
         }
@@ -126,6 +145,7 @@ fn claim_worksite(
     activity_q: &mut Query<&mut crate::components::Activity>,
     path_queue: &mut PathRequestQueue,
     production_map: &std::collections::HashMap<usize, (bool, f32)>,
+    cow_farm_slots: &std::collections::HashSet<usize>,
 ) {
     let max_occupants = match building_def(kind).worksite {
         Some(ws) => ws.max_occupants,
@@ -134,7 +154,9 @@ fn claim_worksite(
 
     // Spatial search for best worksite
     let result = match kind {
-        BuildingKind::Farm => find_farm_target(from, entity_map, town_idx, production_map),
+        BuildingKind::Farm => {
+            find_farm_target(from, entity_map, town_idx, production_map, cow_farm_slots)
+        }
         BuildingKind::GoldMine => find_mine_target(from, entity_map, town_idx, production_map),
         _ => return,
     };
@@ -182,6 +204,7 @@ pub(crate) fn find_farm_target(
     entity_map: &EntityMap,
     town_idx: u32,
     production_map: &std::collections::HashMap<usize, (bool, f32)>,
+    cow_farm_slots: &std::collections::HashSet<usize>,
 ) -> Option<(usize, Vec2, f32)> {
     let max_occ = building_def(BuildingKind::Farm)
         .worksite
@@ -195,6 +218,10 @@ pub(crate) fn find_farm_target(
             WorksiteFallback::TownOnly,
             6400.0,
             |inst, occ| {
+                // Skip cow farms -- they don't need farmer tending
+                if cow_farm_slots.contains(&inst.slot) {
+                    return None;
+                }
                 if occ as i32 >= max_occ {
                     return None;
                 }


### PR DESCRIPTION
## Summary
- Cow farms render with brown tint (growing) / orange-gold (ready) vs green/gold for crop farms
- Farmers skip cow farms during work targeting -- cow farms are autonomous and don't need tending
- New test: `farmers_skip_cow_farms` validates that `find_farm_target` returns None for cow-only farms

## Changes
- `npc_render.rs`: query `FarmModeComp`, use distinct brown color palette for cow farm overlays
- `work_targeting.rs`: accept `cow_farm_slots` HashSet, filter cow farms from `find_farm_target`
- `decision/mod.rs`: build cow_farm_slots set once per decision cycle, pass to farm probe
- `economy/tests.rs`: add `farmers_skip_cow_farms` unit test

## Test plan
- [x] cargo clippy --release -- -D warnings clean
- [x] cargo test: 288 passed (287 existing + 1 new)
- [ ] manual: build farms, toggle to Cows, verify brown overlay and farmers not walking to cow farms