### PR TITLE
feat: maze worldgen style

### DIFF
--- a/rust/src/ui/main_menu.rs
+++ b/rust/src/ui/main_menu.rs
@@ -60,6 +60,7 @@ pub struct MenuState {
     pub initialized: bool,
     pub endless_mode: bool,
     pub endless_strength: f32,
+    pub gen_style: WorldGenStyle,
 }
 
 fn is_player_home_job(job: Job) -> bool {
@@ -159,6 +160,11 @@ pub fn main_menu_system(
         state.autosave_hours = saved.autosave_hours;
         state.endless_mode = saved.endless_mode;
         state.endless_strength = saved.endless_strength;
+        state.gen_style = match saved.gen_style {
+            0 => WorldGenStyle::Classic,
+            2 => WorldGenStyle::Maze,
+            _ => WorldGenStyle::Continents,
+        };
         strip_disabled_home_jobs(&mut state.npc_counts);
         clamp_player_menu_caps(&mut state);
         state.initialized = true;
@@ -224,6 +230,21 @@ pub fn main_menu_system(
             ui.separator();
             ui.label(egui::RichText::new("World").strong());
             ui.add_space(4.0);
+
+            ui.horizontal(|ui| {
+                ui.label("Map Type:").on_hover_text("Continents: noise-based islands and oceans.\nMaze: corridors and walls with choke points.");
+                let label = match state.gen_style {
+                    WorldGenStyle::Classic => "Classic",
+                    WorldGenStyle::Continents => "Continents",
+                    WorldGenStyle::Maze => "Maze",
+                };
+                egui::ComboBox::from_id_salt("gen_style")
+                    .selected_text(label)
+                    .show_ui(ui, |ui| {
+                        ui.selectable_value(&mut state.gen_style, WorldGenStyle::Continents, "Continents");
+                        ui.selectable_value(&mut state.gen_style, WorldGenStyle::Maze, "Maze");
+                    });
+            });
 
             ui.horizontal(|ui| {
                 ui.label("World Size:").on_hover_text("Total world size in pixels. Larger worlds take longer to generate.");
@@ -372,7 +393,7 @@ pub fn main_menu_system(
             if ui.button(egui::RichText::new("  Play  ").size(18.0)).clicked() {
                 strip_disabled_home_jobs(&mut state.npc_counts);
                 clamp_player_menu_caps(&mut state);
-                wg_config.gen_style = WorldGenStyle::Continents;
+                wg_config.gen_style = state.gen_style;
                 wg_config.world_width = state.world_size;
                 wg_config.world_height = state.world_size;
                 wg_config.num_towns = 1;
@@ -402,7 +423,11 @@ pub fn main_menu_system(
                 }).collect();
                 saved.ai_interval = state.ai_interval;
                 saved.npc_interval = state.npc_interval;
-                saved.gen_style = 1;
+                saved.gen_style = match state.gen_style {
+                    WorldGenStyle::Classic => 0,
+                    WorldGenStyle::Continents => 1,
+                    WorldGenStyle::Maze => 2,
+                };
                 saved.gold_mines_per_town = state.gold_mines as usize;
                 saved.raider_forage_hours = state.raider_forage_hours;
                 saved.difficulty = state.difficulty;

--- a/rust/src/world.rs
+++ b/rust/src/world.rs
@@ -2030,6 +2030,7 @@ pub enum WorldGenStyle {
     Classic,
     #[default]
     Continents,
+    Maze,
 }
 
 /// Configuration for procedural world generation.
@@ -2203,16 +2204,20 @@ pub fn generate_world(
     let mut name_idx = 0;
 
     let is_continents = config.gen_style == WorldGenStyle::Continents;
+    let is_maze = config.gen_style == WorldGenStyle::Maze;
+    let terrain_first = is_continents || is_maze;
 
-    // Continents: generate terrain first so we can reject Water positions
+    // Terrain-first styles: generate terrain before town placement so we can reject invalid cells
     if is_continents {
         generate_terrain_continents(grid);
+    } else if is_maze {
+        generate_terrain_maze(grid);
     }
 
     // All settlement positions for min_distance checks
     let mut all_positions: Vec<Vec2> = Vec::new();
-    // Continents needs more attempts since many positions land in ocean
-    let max_attempts = if is_continents { 5000 } else { 2000 };
+    // Terrain-first styles need more attempts since many positions land on impassable cells
+    let max_attempts = if terrain_first { 5000 } else { 2000 };
     // Step 2: Place towns — single loop driven by TOWN_REGISTRY
     for town_def in TOWN_REGISTRY {
         let count = config.count_for(town_def.kind);
@@ -2224,9 +2229,12 @@ pub fn generate_world(
             let y =
                 rng.random_range(config.world_margin..config.world_height - config.world_margin);
             let pos = Vec2::new(x, y);
-            if is_continents {
+            if terrain_first {
                 let (gc, gr) = grid.world_to_grid(pos);
-                if grid.cell(gc, gr).is_some_and(|c| c.terrain == Biome::Water) {
+                if grid
+                    .cell(gc, gr)
+                    .is_some_and(|c| matches!(c.terrain, Biome::Water | Biome::Rock))
+                {
                     continue;
                 }
             }
@@ -2293,7 +2301,7 @@ pub fn generate_world(
     }
 
     // Step 3: Generate terrain
-    if is_continents {
+    if is_continents || is_maze {
         // Terrain already generated; stamp dirt clearings around settlements
         stamp_dirt(grid, &all_positions);
     } else {
@@ -2309,10 +2317,13 @@ pub fn generate_world(
         let x = rng.random_range(config.world_margin..config.world_width - config.world_margin);
         let y = rng.random_range(config.world_margin..config.world_height - config.world_margin);
         let pos = Vec2::new(x, y);
-        // Not on water
-        if is_continents {
+        // Not on impassable terrain
+        if terrain_first {
             let (gc, gr) = grid.world_to_grid(pos);
-            if grid.cell(gc, gr).is_some_and(|c| c.terrain == Biome::Water) {
+            if grid
+                .cell(gc, gr)
+                .is_some_and(|c| matches!(c.terrain, Biome::Water | Biome::Rock))
+            {
                 continue;
             }
         }
@@ -2803,6 +2814,115 @@ fn generate_terrain_continents(grid: &mut WorldGrid) {
             let cell = &mut grid.cells[row * grid.width + col];
             cell.terrain = biome;
             cell.original_terrain = biome;
+        }
+    }
+}
+
+/// Generate a maze using recursive backtracking.
+/// Corridors are 3 cells wide (Grass), walls are 1 cell wide (Rock).
+/// The maze cell size is 4 grid cells (3 corridor + 1 wall).
+fn generate_terrain_maze(grid: &mut WorldGrid) {
+    use rand::Rng;
+    let mut rng = rand::rng();
+
+    let cell_size = 4usize; // 3 corridor + 1 wall
+    let maze_w = grid.width / cell_size;
+    let maze_h = grid.height / cell_size;
+    if maze_w < 2 || maze_h < 2 {
+        return;
+    }
+
+    // Fill everything with Rock first
+    for cell in &mut grid.cells {
+        cell.terrain = Biome::Rock;
+        cell.original_terrain = Biome::Rock;
+    }
+
+    // Carve helper: set a 3x3 corridor block at maze cell (mx, my) to Grass
+    let carve = |grid: &mut WorldGrid, mx: usize, my: usize| {
+        let base_col = mx * cell_size;
+        let base_row = my * cell_size;
+        for dr in 0..3 {
+            for dc in 0..3 {
+                let c = base_col + dc;
+                let r = base_row + dr;
+                if c < grid.width && r < grid.height {
+                    let idx = r * grid.width + c;
+                    grid.cells[idx].terrain = Biome::Grass;
+                    grid.cells[idx].original_terrain = Biome::Grass;
+                }
+            }
+        }
+    };
+
+    // Carve passage between adjacent maze cells (fills the wall gap)
+    let carve_passage = |grid: &mut WorldGrid, ax: usize, ay: usize, bx: usize, by: usize| {
+        // Mid-point between the two 3x3 blocks -- fill the 3-cell-wide corridor in the wall
+        let mid_col = (ax * cell_size + bx * cell_size) / 2;
+        let mid_row = (ay * cell_size + by * cell_size) / 2;
+        for dr in 0..3 {
+            for dc in 0..3 {
+                let c = mid_col + dc;
+                let r = mid_row + dr;
+                if c < grid.width && r < grid.height {
+                    let idx = r * grid.width + c;
+                    grid.cells[idx].terrain = Biome::Grass;
+                    grid.cells[idx].original_terrain = Biome::Grass;
+                }
+            }
+        }
+    };
+
+    // Recursive backtracking maze generation
+    let mut visited = vec![false; maze_w * maze_h];
+    let mut stack: Vec<(usize, usize)> = Vec::new();
+
+    // Start from center
+    let start_x = maze_w / 2;
+    let start_y = maze_h / 2;
+    visited[start_y * maze_w + start_x] = true;
+    carve(grid, start_x, start_y);
+    stack.push((start_x, start_y));
+
+    while let Some(&(cx, cy)) = stack.last() {
+        // Collect unvisited neighbors
+        let mut neighbors: Vec<(usize, usize)> = Vec::new();
+        if cx > 0 && !visited[cy * maze_w + (cx - 1)] {
+            neighbors.push((cx - 1, cy));
+        }
+        if cx + 1 < maze_w && !visited[cy * maze_w + (cx + 1)] {
+            neighbors.push((cx + 1, cy));
+        }
+        if cy > 0 && !visited[(cy - 1) * maze_w + cx] {
+            neighbors.push((cx, cy - 1));
+        }
+        if cy + 1 < maze_h && !visited[(cy + 1) * maze_w + cx] {
+            neighbors.push((cx, cy + 1));
+        }
+
+        if neighbors.is_empty() {
+            stack.pop();
+        } else {
+            let idx = rng.random_range(0..neighbors.len());
+            let (nx, ny) = neighbors[idx];
+            visited[ny * maze_w + nx] = true;
+            carve(grid, nx, ny);
+            carve_passage(grid, cx, cy, nx, ny);
+            stack.push((nx, ny));
+        }
+    }
+
+    // Add some Forest patches in corridors for wood resources
+    for row in 0..grid.height {
+        for col in 0..grid.width {
+            let idx = row * grid.width + col;
+            if grid.cells[idx].terrain == Biome::Grass {
+                let noise_val = ((col * 7 + row * 13) % 100) as f32 / 100.0;
+                if noise_val > 0.85 {
+                    grid.cells[idx].terrain = Biome::Forest;
+                    grid.cells[idx].original_terrain = Biome::Forest;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add `WorldGenStyle::Maze` variant for recursive-backtracking maze generation
- 3-cell-wide corridors (Grass) separated by 1-cell Rock walls
- ~15% of corridor cells become Forest for wood resources
- Towns/mines reject Rock cells during placement (same pattern as Continents rejects Water)
- Main menu Map Type dropdown (Continents/Maze), saved to user settings
- Dirt clearings stamped around towns for buildable space

## Compliance
- **k8s.md**: no new entity types or registry changes -- uses existing Biome/WorldCell system
- **authority.md**: no GPU/ECS data changes -- purely terrain generation
- **performance.md**: maze generation is one-time at world init, not a hot path. recursive backtracking is O(cells) with no repeated scans

Closes #85

## Test plan
- [x] cargo clippy --release -- -D warnings clean
- [x] cargo test 287 passed
- [ ] verify maze generates navigable corridors in-game
- [ ] verify towns spawn in corridors and are reachable
- [ ] verify pathfinding works through maze corridors
- [ ] verify Map Type dropdown persists across menu visits