### PR TITLE
feat: guard tower building (+range, wall adjacency)

### DIFF
--- a/rust/src/constants/buildings.rs
+++ b/rust/src/constants/buildings.rs
@@ -1,7 +1,9 @@
 //! Building registry — single source of truth for all building definitions.
 
 use super::npcs::{ItemKind, LootDrop};
-use super::{FOUNTAIN_TOWER, MINE_WORK_RADIUS, ResourceKind, TOWER_STATS, TowerStats};
+use super::{
+    FOUNTAIN_TOWER, GUARD_TOWER_STATS, MINE_WORK_RADIUS, ResourceKind, TOWER_STATS, TowerStats,
+};
 use crate::world::BuildingKind;
 
 /// Tile specification: single 16x16 sprite or 2x2 composite of four 16x16 sprites.
@@ -688,7 +690,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         cost: 2,
         label: "Gate",
         help: "Passable wall segment",
-        tooltip: "Gate — connects to walls, friendlies pass\nthrough freely. Raiders must breach it.\nHP: 120. Upgrades with wall tier.",
+        tooltip: "Gate -- connects to walls, friendlies pass\nthrough freely. Raiders must breach it.\nHP: 120. Upgrades with wall tier.",
         player_buildable: true,
         raider_buildable: false,
         placement: PlacementMode::TownGrid,
@@ -700,6 +702,28 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         is_unit_home: false,
         worksite: None,
         autotile: true,
+    },
+    // Guard Tower (elevated tower, +range, requires wall adjacency)
+    BuildingDef {
+        kind: BuildingKind::GuardTower,
+        display: DisplayCategory::Tower,
+        tile: TileSpec::External("sprites/tower-1.png"),
+        hp: 1500.0,
+        cost: 60,
+        label: "Guard Tower",
+        help: "Tower with +range, needs wall",
+        tooltip: "Elevated guard tower -- 50% more range than\nstandard tower. Must be placed next to a wall.\n20 dmg, 300 range, 1.5s cooldown. HP: 1500",
+        player_buildable: true,
+        raider_buildable: false,
+        placement: PlacementMode::TownGrid,
+        is_tower: true,
+        tower_stats: Some(GUARD_TOWER_STATS),
+        on_place: OnPlace::None,
+        spawner: None,
+        save_key: Some("guard_towers"),
+        is_unit_home: false,
+        worksite: None,
+        autotile: false,
     },
 ];
 

--- a/rust/src/constants/mod.rs
+++ b/rust/src/constants/mod.rs
@@ -281,6 +281,16 @@ pub const TOWER_STATS: TowerStats = TowerStats {
     max_hp: 1000.0,
 };
 
+pub const GUARD_TOWER_STATS: TowerStats = TowerStats {
+    range: 300.0,
+    damage: 20.0,
+    cooldown: 1.5,
+    proj_speed: 250.0,
+    proj_lifetime: 1.5,
+    hp_regen: 0.0,
+    max_hp: 1500.0,
+};
+
 // ============================================================================
 // SQUAD CONSTANTS
 // ============================================================================
@@ -594,6 +604,7 @@ mod tests {
             BuildingKind::Quarry,
             BuildingKind::MasonHome,
             BuildingKind::Gate,
+            BuildingKind::GuardTower,
         ];
         for kind in kinds {
             let def = building_def(kind);

--- a/rust/src/systems/combat.rs
+++ b/rust/src/systems/combat.rs
@@ -648,13 +648,14 @@ pub fn building_tower_system(
     tower.tower_cooldowns.retain(|slot, _| {
         entity_map
             .get_instance(*slot)
-            .is_some_and(|i| i.kind == BuildingKind::Tower)
+            .is_some_and(|i| matches!(i.kind, BuildingKind::Tower | BuildingKind::GuardTower))
     });
 
     // Collect tower data with stack-allocated upgrade levels (no heap clone)
     const MAX_UPGRADES: usize = crate::constants::TOWER_UPGRADES.len();
     let towers: Vec<(usize, Vec2, i32, i32, [u8; MAX_UPGRADES], usize, Entity)> = entity_map
         .iter_kind(BuildingKind::Tower)
+        .chain(entity_map.iter_kind(BuildingKind::GuardTower))
         .filter_map(|inst| {
             let entity = *entity_map.entities.get(&inst.slot)?;
             let tbs = tower_bld_q.get(entity).ok()?;

--- a/rust/src/systems/health/mod.rs
+++ b/rust/src/systems/health/mod.rs
@@ -888,7 +888,12 @@ pub fn death_system(
             } else if let Some(tower_faction) = res
                 .entity_map
                 .get_instance(killer_slot)
-                .filter(|i| i.kind == BuildingKind::Fountain || i.kind == BuildingKind::Tower)
+                .filter(|i| {
+                    matches!(
+                        i.kind,
+                        BuildingKind::Fountain | BuildingKind::Tower | BuildingKind::GuardTower
+                    )
+                })
                 .map(|i| (i.faction, i.town_idx as usize))
             {
                 // Tower/fountain killer — XP, kills, loot deposit
@@ -899,10 +904,10 @@ pub fn death_system(
                 let Some(inst) = res.entity_map.get_instance(killer_slot) else {
                     continue;
                 };
-                let kind_name = if inst.kind == BuildingKind::Tower {
-                    "Tower"
-                } else {
-                    "Fountain"
+                let kind_name = match inst.kind {
+                    BuildingKind::Tower => "Tower",
+                    BuildingKind::GuardTower => "Guard Tower",
+                    _ => "Fountain",
                 };
                 let Some(&tower_entity) = res.entity_map.entities.get(&killer_slot) else {
                     continue;

--- a/rust/src/systems/remote.rs
+++ b/rust/src/systems/remote.rs
@@ -167,6 +167,7 @@ pub fn parse_building_kind(s: &str) -> Option<BuildingKind> {
         "Wall" => Some(BuildingKind::Wall),
         "Gate" => Some(BuildingKind::Gate),
         "Tower" => Some(BuildingKind::Tower),
+        "GuardTower" => Some(BuildingKind::GuardTower),
         "Merchant" => Some(BuildingKind::Merchant),
         "Casino" => Some(BuildingKind::Casino),
         _ => None,

--- a/rust/src/ui/game_hud.rs
+++ b/rust/src/ui/game_hud.rs
@@ -993,7 +993,7 @@ fn tower_upgrade_window(
     let inst_exists = bld
         .entity_map
         .get_instance(slot)
-        .is_some_and(|i| i.kind == BuildingKind::Tower);
+        .is_some_and(|i| matches!(i.kind, BuildingKind::Tower | BuildingKind::GuardTower));
     if !inst_exists {
         ui_state.tower_upgrade_slot = None;
         return;
@@ -2715,7 +2715,7 @@ fn building_inspector_content(
                 }
             }
 
-            BuildingKind::Tower => {
+            BuildingKind::Tower | BuildingKind::GuardTower => {
                 // Resolve per-instance stats from ECS TowerBuildingState
                 let slot = bld_slot.unwrap_or(usize::MAX);
                 let (level, upgrade_levels_clone) = bld_entity

--- a/rust/src/world.rs
+++ b/rust/src/world.rs
@@ -696,6 +696,22 @@ pub fn place_building(
             return Err("cannot build in foreign territory");
         }
 
+        // Guard tower requires at least one adjacent wall
+        if kind == BuildingKind::GuardTower {
+            let has_adj_wall = [(0i32, 1i32), (0, -1), (1, 0), (-1, 0)]
+                .iter()
+                .any(|&(dc, dr)| {
+                    let nc = gc as i32 + dc;
+                    let nr = gr as i32 + dr;
+                    entity_map
+                        .get_at_grid(nc, nr)
+                        .is_some_and(|inst| inst.kind == BuildingKind::Wall)
+                });
+            if !has_adj_wall {
+                return Err("guard tower must be adjacent to a wall");
+            }
+        }
+
         // Wilderness buildings must be within road or fountain buildable area
         if def.placement == crate::constants::PlacementMode::Wilderness {
             if kind.is_road() {
@@ -1212,6 +1228,7 @@ pub enum BuildingKind {
     Quarry,
     MasonHome,
     Gate,
+    GuardTower,
 }
 
 impl BuildingKind {


### PR DESCRIPTION
## Summary
- New `BuildingKind::GuardTower` -- elevated defensive tower with 50% more range than standard tower
- Wall adjacency validation: placement requires at least one adjacent wall tile
- Uses existing tower system (`building_tower_system`) with `GUARD_TOWER_STATS` (300 range, 20 dmg, 1500 HP)
- Full integration: build menu (Tower tab), inspector (upgrade panel), combat logging, BRP endpoint, save/load

## Changes
- `world.rs`: added `GuardTower` variant + wall-adjacency placement check
- `constants/mod.rs`: added `GUARD_TOWER_STATS` constant
- `constants/buildings.rs`: added registry entry (index 22)
- `systems/combat.rs`: tower system iterates both Tower and GuardTower
- `systems/health/mod.rs`: tower kill attribution includes GuardTower
- `ui/game_hud.rs`: inspector shows tower stats/upgrades for GuardTower
- `systems/remote.rs`: BRP endpoint recognizes "GuardTower"

## Compliance
- **k8s.md**: follows Def->Instance->Controller. 1 enum variant + 1 registry entry.
- **authority.md**: CPU-authoritative placement/stats. No GPU readback changes.
- **performance.md**: no new hot paths. Chains `iter_kind(GuardTower)` onto existing tower iteration (O(n) total).

## Tests
- `cargo clippy --release -- -D warnings`: clean
- `cargo test`: 288 passed, 0 failed

Closes #92