### PR TITLE
feature: gate building -- wall-like passable segment

### DIFF
--- a/rust/src/constants/buildings.rs
+++ b/rust/src/constants/buildings.rs
@@ -679,6 +679,28 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: false,
     },
+    // Gate (wall-like, passable for friendlies)
+    BuildingDef {
+        kind: BuildingKind::Gate,
+        display: DisplayCategory::Military,
+        tile: TileSpec::External("sprites/wood_walls_131x32.png"),
+        hp: 120.0,
+        cost: 2,
+        label: "Gate",
+        help: "Passable wall segment",
+        tooltip: "Gate — connects to walls, friendlies pass\nthrough freely. Raiders must breach it.\nHP: 120. Upgrades with wall tier.",
+        player_buildable: true,
+        raider_buildable: false,
+        placement: PlacementMode::TownGrid,
+        is_tower: false,
+        tower_stats: None,
+        on_place: OnPlace::None,
+        spawner: None,
+        save_key: Some("gates"),
+        is_unit_home: false,
+        worksite: None,
+        autotile: true,
+    },
 ];
 
 /// Look up a building definition by kind. Panics if kind is not in registry.

--- a/rust/src/constants/mod.rs
+++ b/rust/src/constants/mod.rs
@@ -590,6 +590,10 @@ mod tests {
             BuildingKind::Casino,
             BuildingKind::TreeNode,
             BuildingKind::RockNode,
+            BuildingKind::LumberMill,
+            BuildingKind::Quarry,
+            BuildingKind::MasonHome,
+            BuildingKind::Gate,
         ];
         for kind in kinds {
             let def = building_def(kind);

--- a/rust/src/gpu.rs
+++ b/rust/src/gpu.rs
@@ -1406,7 +1406,7 @@ fn populate_tile_flags(
         if inst.kind.is_road() {
             flags[idx] |= crate::constants::TILE_ROAD;
         }
-        if inst.kind == crate::world::BuildingKind::Wall {
+        if inst.kind.is_wall_like() {
             let faction = world_data
                 .towns
                 .get(inst.town_idx as usize)

--- a/rust/src/systemparams.rs
+++ b/rust/src/systemparams.rs
@@ -47,11 +47,7 @@ impl WorldState<'_> {
         } else {
             0
         };
-        let wall_level = if kind == crate::world::BuildingKind::Wall {
-            1
-        } else {
-            0
-        };
+        let wall_level = if kind.is_wall_like() { 1 } else { 0 };
         crate::world::place_building(
             &mut self.entity_slots,
             &mut self.entity_map,

--- a/rust/src/systems/remote.rs
+++ b/rust/src/systems/remote.rs
@@ -165,6 +165,7 @@ pub fn parse_building_kind(s: &str) -> Option<BuildingKind> {
         "StoneRoad" => Some(BuildingKind::StoneRoad),
         "MetalRoad" => Some(BuildingKind::MetalRoad),
         "Wall" => Some(BuildingKind::Wall),
+        "Gate" => Some(BuildingKind::Gate),
         "Tower" => Some(BuildingKind::Tower),
         "Merchant" => Some(BuildingKind::Merchant),
         "Casino" => Some(BuildingKind::Casino),

--- a/rust/src/ui/game_hud.rs
+++ b/rust/src/ui/game_hud.rs
@@ -2608,8 +2608,8 @@ fn building_inspector_content(
                 }
             }
 
-            BuildingKind::Wall => {
-                // Wall tier info + upgrade button
+            BuildingKind::Wall | BuildingKind::Gate => {
+                // Wall/gate tier info + upgrade button
                 if let Some(_wall_inst) = bld.entity_map.find_by_position(world_pos) {
                     let wall_lv = bld_entity
                         .and_then(|e| bld.wall_level_q.get(e).ok())

--- a/rust/src/world.rs
+++ b/rust/src/world.rs
@@ -325,6 +325,8 @@ fn is_kind_at(entity_map: &EntityMap, col: usize, row: usize, kind: BuildingKind
         .is_some_and(|inst| {
             if kind.is_road() {
                 inst.kind.is_road()
+            } else if kind.is_wall_like() {
+                inst.kind.is_wall_like()
             } else {
                 inst.kind == kind
             }
@@ -385,6 +387,10 @@ pub fn update_autotile_around(
         let neighbor_kind = inst.kind;
         if kind.is_road() {
             if !neighbor_kind.is_road() {
+                continue;
+            }
+        } else if kind.is_wall_like() {
+            if !neighbor_kind.is_wall_like() {
                 continue;
             }
         } else if neighbor_kind != kind {
@@ -771,7 +777,7 @@ pub fn place_building(
     if kind == BuildingKind::Waypoint {
         ecmds.insert(WaypointOrder(overrides.patrol_order));
     }
-    if kind == BuildingKind::Wall {
+    if kind.is_wall_like() {
         ecmds.insert(WallLevel(overrides.wall_level));
     }
     if kind == BuildingKind::MinerHome {
@@ -1205,12 +1211,18 @@ pub enum BuildingKind {
     LumberMill,
     Quarry,
     MasonHome,
+    Gate,
 }
 
 impl BuildingKind {
     /// True for any road tier (dirt, stone, metal).
     pub fn is_road(self) -> bool {
         matches!(self, Self::Road | Self::StoneRoad | Self::MetalRoad)
+    }
+
+    /// True for wall-like buildings that auto-tile together (Wall, Gate).
+    pub fn is_wall_like(self) -> bool {
+        matches!(self, Self::Wall | Self::Gate)
     }
 
     /// Buildable radius (in grid tiles) granted by this road tier.
@@ -1805,6 +1817,8 @@ impl WorldGrid {
         self.building_cost_cells.clear();
 
         self.apply_building_overlay(entity_map, BuildingKind::Wall, 0);
+        // Gates are passable (same cost as dirt road) -- faction gating is behavioral
+        self.apply_building_overlay(entity_map, BuildingKind::Gate, 67);
         // Apply road overlays — higher tiers override lower (iter order: dirt, stone, metal)
         for kind in [
             BuildingKind::Road,


### PR DESCRIPTION
## Summary

Adds `BuildingKind::Gate` -- a wall-like building that connects to walls via auto-tiling but is passable in the pathfinding grid (cost 67, same as dirt road). Gates have 120 HP, cost 2 food, share wall tier upgrades, and appear in the Military build menu.

Changes:
- `BuildingKind::Gate` variant + `BuildingDef` registry entry with `autotile: true`
- `is_wall_like()` helper on `BuildingKind` -- gates and walls auto-tile together
- `is_kind_at` and `update_autotile_around` use `is_wall_like()` for neighbor matching
- `sync_building_costs` applies gate overlay with cost 67 (passable) vs wall cost 0 (impassable)
- GPU terrain flags mark gates with `TILE_WALL` so GPU compute sees them as barriers
- Wall upgrade UI handles both `Wall` and `Gate` kinds
- BRP remote command support for `Gate`
- Save/load via `save_key: "gates"`

Closes #90

## Compliance

- **k8s.md**: follows Def/Instance/Controller -- 1 enum variant + 1 registry entry, `WallLevel` ECS component reused
- **authority.md**: n/a -- no GPU readback changes, gate passability is CPU pathfind-only
- **performance.md**: n/a -- no hot-path changes. `is_wall_like()` is O(1) match, called only at autotile time (placement events)