### PR TITLE
feat: npc skills foundation (component, spawn, save/load)

### DIFF
--- a/rust/src/components.rs
+++ b/rust/src/components.rs
@@ -491,6 +491,15 @@ pub struct NpcStats {
     pub xp: i32,
 }
 
+/// Per-NPC skill proficiencies (0.0-100.0). Grow from doing work.
+#[derive(Component, Clone, Default, Reflect, serde::Serialize, serde::Deserialize)]
+#[reflect(Component)]
+pub struct NpcSkills {
+    pub farming: f32,
+    pub combat: f32,
+    pub dodge: f32,
+}
+
 // ============================================================================
 // STEALING / EQUIPMENT COMPONENTS
 // ============================================================================

--- a/rust/src/constants/mod.rs
+++ b/rust/src/constants/mod.rs
@@ -298,6 +298,16 @@ pub const GUARD_TOWER_STATS: TowerStats = TowerStats {
 /// Maximum number of player-controlled squads.
 pub const MAX_SQUADS: usize = 10;
 
+// ============================================================================
+// NPC SKILLS / PROFICIENCY
+// ============================================================================
+
+pub const FARMING_SKILL_RATE: f32 = 0.02;
+pub const COMBAT_SKILL_RATE: f32 = 1.0;
+pub const DODGE_SKILL_RATE: f32 = 0.5;
+pub const MAX_PROFICIENCY: f32 = 100.0;
+pub const DODGE_PROF_MAX_CHANCE: f32 = 0.25;
+
 /// Default real-time seconds between AI decisions.
 pub const DEFAULT_AI_INTERVAL: f32 = 5.0;
 

--- a/rust/src/save.rs
+++ b/rust/src/save.rs
@@ -470,6 +470,8 @@ pub struct NpcSaveData {
     pub helmet: Option<[f32; 2]>,
     #[serde(default)]
     pub armor: Option<[f32; 2]>,
+    #[serde(default)]
+    pub skills: crate::components::NpcSkills,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -1516,6 +1518,7 @@ pub fn collect_npc_data(
     carried_loot_q: &Query<&CarriedLoot>,
     equipment_q: &Query<&NpcEquipment>,
     has_energy_q: &Query<&HasEnergy>,
+    skills_q: &Query<&crate::components::NpcSkills>,
 ) -> Vec<NpcSaveData> {
     let mut npcs = Vec::new();
     for npc in entity_map.iter_npcs() {
@@ -1601,6 +1604,7 @@ pub fn collect_npc_data(
             weapon: None,
             helmet: None,
             armor: None,
+            skills: skills_q.get(npc.entity).cloned().unwrap_or_default(),
         });
     }
     npcs
@@ -1656,6 +1660,7 @@ pub struct SaveNpcQueries<'w, 's> {
     pub equipment_q: Query<'w, 's, &'static NpcEquipment>,
     pub has_energy_q: Query<'w, 's, &'static HasEnergy>,
     pub npc_stats_q: Query<'w, 's, &'static NpcStats>,
+    pub skills_q: Query<'w, 's, &'static crate::components::NpcSkills>,
 }
 
 /// NPC tracking resources for load.
@@ -2060,6 +2065,7 @@ pub fn save_game_system(
         &nq.carried_loot_q,
         &nq.equipment_q,
         &nq.has_energy_q,
+        &nq.skills_q,
     );
     let building_hp = collect_building_hp(&building_query, &entity_map);
     let bld_state = collect_building_state_snapshot(&bld_component_q);
@@ -2195,6 +2201,7 @@ pub fn autosave_system(
         &nq.carried_loot_q,
         &nq.equipment_q,
         &nq.has_energy_q,
+        &nq.skills_q,
     );
     let building_hp = collect_building_hp(&building_query, &entity_map);
     let bld_state = collect_building_state_snapshot(&bld_component_q);
@@ -2291,6 +2298,7 @@ pub fn spawn_npcs_from_save(
             carried_gold: npc.carried_gold,
             carried_equipment: npc.carried_equipment.clone(),
             squad_id: npc.squad_id,
+            skills: Some(npc.skills.clone()),
         };
 
         // Patrol units always get starting_post=0 on load (patrol route rebuilt from world)

--- a/rust/src/systems/spawn.rs
+++ b/rust/src/systems/spawn.rs
@@ -91,6 +91,7 @@ pub struct NpcSpawnOverrides {
     pub carried_gold: Option<i32>,
     pub carried_equipment: Vec<crate::constants::LootItem>,
     pub squad_id: Option<i32>,
+    pub skills: Option<crate::components::NpcSkills>,
 }
 
 /// Shared NPC spawn: creates entity, emits GPU updates, registers in tracking caches.
@@ -286,6 +287,7 @@ pub fn materialize_npc(
                 .unwrap_or_else(|| generate_name(job, idx)),
             xp: overrides.xp.unwrap_or(0),
         },
+        overrides.skills.clone().unwrap_or_default(),
     ));
     if let Some(sq) = overrides.squad_id {
         ecmds.insert(SquadId(sq));

--- a/rust/src/systems/stats/mod.rs
+++ b/rust/src/systems/stats/mod.rs
@@ -696,6 +696,12 @@ fn is_combat_upgrade(idx: usize) -> bool {
     UPGRADES.nodes[idx].is_combat_stat
 }
 
+/// Convert proficiency (0-100) to a multiplier.
+/// 0 = 1.0x (no bonus), 50 = 1.25x, 100 = 1.5x.
+pub fn proficiency_mult(value: f32) -> f32 {
+    1.0 + (value.clamp(0.0, 100.0) / 100.0) * 0.5
+}
+
 // ============================================================================
 // STAT RESOLVER
 // ============================================================================

--- a/rust/src/systems/stats/tests.rs
+++ b/rust/src/systems/stats/tests.rs
@@ -439,6 +439,28 @@ fn resolve_tower_instance_stats_level_scales() {
     assert!(stats_lv10.range > stats_lv0.range);
 }
 
+// -- proficiency_mult ----------------------------------------------------
+
+#[test]
+fn proficiency_mult_zero_is_one() {
+    assert!((proficiency_mult(0.0) - 1.0).abs() < f32::EPSILON);
+}
+
+#[test]
+fn proficiency_mult_fifty_is_one_point_two_five() {
+    assert!((proficiency_mult(50.0) - 1.25).abs() < 0.001);
+}
+
+#[test]
+fn proficiency_mult_hundred_is_one_point_five() {
+    assert!((proficiency_mult(100.0) - 1.5).abs() < f32::EPSILON);
+}
+
+#[test]
+fn proficiency_mult_clamps_above_100() {
+    assert!((proficiency_mult(200.0) - 1.5).abs() < f32::EPSILON);
+}
+
 // -- UpgradeRegistry::stat_mult ------------------------------------------
 
 #[test]


### PR DESCRIPTION
## Summary
- Added NpcSkills component (farming/combat/dodge f32 fields, 0.0-100.0)
- All NPCs spawn with NpcSkills::default() (all 0.0)
- Save/load round-trip with #[serde(default)] backward compat
- proficiency_mult() helper: 0=1.0x, 50=1.25x, 100=1.5x
- Skill rate constants (FARMING_SKILL_RATE, COMBAT_SKILL_RATE, DODGE_SKILL_RATE, etc)
- 4 new proficiency_mult tests

## Compliance
- **k8s.md**: NpcSkills is CR instance state (like NpcStats, Health). No Def changes.
- **authority.md**: CPU-only component, never sent to GPU. Compliant.
- **performance.md**: no new iteration, no hot paths. Component added to spawn bundle only.

## Tests
- cargo clippy --release -D warnings: clean
- cargo test: 296 passed, 0 failed

## Files
- components.rs: NpcSkills component
- constants/mod.rs: skill rate constants
- systems/stats/mod.rs: proficiency_mult()
- systems/spawn.rs: NpcSkills in spawn bundle + NpcSpawnOverrides.skills
- save.rs: NpcSaveData.skills field + serialize/restore
- systems/stats/tests.rs: 4 proficiency_mult tests

Closes #110