### PR TITLE
fix: casino popup alpha transparency

### DIFF
--- a/rust/src/ui/blackjack.rs
+++ b/rust/src/ui/blackjack.rs
@@ -105,7 +105,7 @@ const CARD_GAP: f32 = 6.0;
 const CARD_ROUNDING: f32 = 4.0;
 
 // Table colors
-const FELT_GREEN: egui::Color32 = egui::Color32::from_rgb(25, 75, 38);
+const FELT_GREEN: egui::Color32 = egui::Color32::from_rgba_premultiplied(25, 75, 38, 230);
 const FELT_BORDER: egui::Color32 = egui::Color32::from_rgb(50, 110, 60);
 const CARD_FACE: egui::Color32 = egui::Color32::from_rgb(250, 248, 240);
 const CARD_BACK: egui::Color32 = egui::Color32::from_rgb(40, 60, 120);


### PR DESCRIPTION
## Summary
- Changed FELT_GREEN from `from_rgb(25, 75, 38)` (fully opaque) to `from_rgba_premultiplied(25, 75, 38, 230)` (semi-transparent)
- Matches the transparency style of other UI panels (build menu uses alpha 230)

## Compliance
- **k8s.md**: n/a (UI color constant only)
- **authority.md**: n/a (no data ownership changes)
- **performance.md**: n/a (no hot paths, single constant change)

## Tests
- cargo clippy --release -D warnings: clean
- cargo test: 292 passed

Closes #118