### PR TITLE
feat: combat proficiency -- damage/cooldown scaling + kill grant

### DIFF
--- a/docs/specs/npc-skills.md
+++ b/docs/specs/npc-skills.md
@@ -1,6 +1,6 @@
 # NPC Skills & Proficiency
 
-Per-NPC skill progression with Disgaea-style unclamped scaling. Level 9999 = godlike.
+Per-NPC skill progression with unclamped unclamped scaling. Level 9999 = godlike.
 
 ## Goal
 
@@ -21,7 +21,7 @@ Add persistent, per-NPC proficiency that improves with experience and directly i
 - Skill belongs to NPC instance -- newly spawned replacement starts at 0
 - Persisted via save/load with serde(default) backward compat
 
-## Scaling formula (Disgaea-style)
+## Scaling formula (unclamped)
 
 One formula for all skills:
 
@@ -56,7 +56,7 @@ Dodge is the exception: the proficiency_mult formula applies to damage/farming s
 - `FARMING_SKILL_RATE = 0.02` per game hour tending
 - `DODGE_SKILL_RATE = 0.5` per dodge event
 - All capped at `MAX_PROFICIENCY = 9999.0`
-- No diminishing returns on gain rate -- linear accumulation, Disgaea-style
+- No diminishing returns on gain rate -- linear accumulation, unclamped
 
 ## Constants
 

--- a/docs/specs/npc-skills.md
+++ b/docs/specs/npc-skills.md
@@ -1,60 +1,91 @@
 # NPC Skills & Proficiency
 
-Stage 16b. Implementation spec for per-NPC skill progression.
+Per-NPC skill progression with Disgaea-style unclamped scaling. Level 9999 = godlike.
 
 ## Goal
 
-Add persistent, per-NPC proficiency that improves with experience and directly impacts how well NPCs perform their work (farm, fight, dodge, etc.).
+Add persistent, per-NPC proficiency that improves with experience and directly impacts how well NPCs perform their work (farm, fight, dodge, etc.). High proficiency should feel massively rewarding -- a level 9999 NPC is a god compared to a fresh spawn.
 
 ## Design constraints
 
 - Job determines what an NPC can do. Skills determine how well they do it.
-- Proficiency is additive/scalar, not a replacement for existing job stats/upgrades/traits.
+- Proficiency is additive/scalar, stacks with existing job stats/upgrades/traits.
+- No artificial caps on the multiplier -- let the numbers grow. Only the proficiency VALUE caps at MAX_PROFICIENCY (9999).
 - Keep deterministic enough for tests and profiling; avoid expensive per-frame randomness.
 
 ## Data model
 
-- Add `NpcSkills` component (or resource-backed cache keyed by `NpcIndex`):
-  `farm: u16`, `combat: u16`, `dodge: u16`, optional future fields (`craft`, `leadership`, etc.)
-- Range: store as integer points 0..1000 internally; expose as 0.0..100.0 in UI
-- Add helper functions: `skill_to_pct(points) -> f32`, `skill_multiplier(points, max_bonus) -> f32`, `add_skill_xp(points, delta_xp)`
-- Persist across respawn only if desired by design; default v1 behavior: skill belongs to NPC instance (newly spawned replacement starts at baseline)
+- `NpcSkills` component: `farming: f32`, `combat: f32`, `dodge: f32`
+- Range: 0.0 to MAX_PROFICIENCY (9999.0)
+- Stored as f32, displayed as integer in UI
+- Skill belongs to NPC instance -- newly spawned replacement starts at 0
+- Persisted via save/load with serde(default) backward compat
 
-## v1 math (safe, bounded)
+## Scaling formula (Disgaea-style)
 
-- Farming: `farm_mult = 1.0 + farm_prof * 0.005` (max +50%) — apply to tended farm growth/harvest throughput
-- Combat: `combat_mult = 1.0 + combat_prof * 0.004` (max +40%) — apply to effective damage and/or cooldown efficiency
-- Dodge: `dodge_mult = 1.0 + dodge_prof * 0.006` (max +60%) — apply to dodge decision weight / projectile avoidance strength
+One formula for all skills:
 
-## XP gain model
+```rust
+pub fn proficiency_mult(value: f32) -> f32 {
+    1.0 + value * 0.01
+}
+```
 
-- Farming XP: gain when farm work ticks and on successful harvest
-- Combat XP: gain on attack attempts and bonus on confirmed hit/kill
-- Dodge XP: gain when near-miss/projectile avoidance logic triggers
-- Diminishing returns: scale XP gain by `(1.0 - proficiency_pct)` so early growth is faster than late growth
+| Prof  | Multiplier | Feel           |
+|-------|-----------|----------------|
+| 0     | 1.0x      | Fresh spawn    |
+| 100   | 2.0x      | Experienced    |
+| 500   | 6.0x      | Veteran        |
+| 1000  | 11.0x     | Elite          |
+| 5000  | 51.0x     | Legendary      |
+| 9999  | 101.0x    | Godlike        |
 
-## System integration points
+No clamp on the multiplier. MAX_PROFICIENCY (9999) only caps the proficiency value, not the effect.
 
-- `systems/economy.rs`: farm growth/harvest uses farming proficiency multiplier
-- `systems/stats.rs` / combat pipeline: incorporate combat proficiency in resolved/effective combat output path
-- GPU dodge path (`gpu/npc_compute.wgsl` + sync path): pass dodge proficiency signal into avoidance weighting (or CPU-side precomputed dodge factor buffer)
-- `systems/spawn.rs`: initialize `NpcSkills` baseline by job
-- `systems/health.rs` and `systems/behavior.rs`: optional hooks for dodge/combat XP triggers
+### Application per skill
 
-## UI/UX
+- **Combat**: `damage *= proficiency_mult(combat)`, `cooldown /= proficiency_mult(combat)`
+- **Farming**: `growth_rate *= proficiency_mult(farming)` for tended farms
+- **Dodge**: miss chance = `min(dodge_prof * 0.0025, 0.50)` -- hard cap at 50% dodge chance (can't be invincible)
 
-- Inspector (`ui/game_hud.rs`): show Skill panel: Farm / Combat / Dodge proficiency bars + numeric values
-- Roster (`ui/left_panel.rs`): optional columns/sort for top relevant proficiency by job
-- Tooltip copy: explain that proficiency increases with activity and improves effectiveness
+Dodge is the exception: the proficiency_mult formula applies to damage/farming scaling, but dodge chance uses a separate linear formula with a hard cap since >100% dodge would break combat.
 
-## Balancing guidance
+## Skill gain rates
 
-- Keep proficiency impact weaker than major tech-tree upgrades at low-mid values
-- Cap total stacked multipliers (traits + upgrades + proficiency) to avoid runaway scaling
-- Profile impact under high NPC counts; prefer cached multipliers updated on skill change, not recomputed everywhere each frame
+- `COMBAT_SKILL_RATE = 1.0` per kill
+- `FARMING_SKILL_RATE = 0.02` per game hour tending
+- `DODGE_SKILL_RATE = 0.5` per dodge event
+- All capped at `MAX_PROFICIENCY = 9999.0`
+- No diminishing returns on gain rate -- linear accumulation, Disgaea-style
+
+## Constants
+
+```rust
+pub const FARMING_SKILL_RATE: f32 = 0.02;
+pub const COMBAT_SKILL_RATE: f32 = 1.0;
+pub const DODGE_SKILL_RATE: f32 = 0.5;
+pub const MAX_PROFICIENCY: f32 = 9999.0;
+pub const DODGE_PROF_MAX_CHANCE: f32 = 0.50;
+```
+
+## System integration
+
+- `systems/stats.rs`: resolve_combat_stats takes prof_combat, applies proficiency_mult to damage and inverse to cooldown
+- `systems/economy.rs`: growth_system applies proficiency_mult to tended farm growth rate
+- `systems/combat.rs`: process_proj_hits applies dodge miss chance (capped)
+- `systems/health.rs`: death processing grants combat skill on kill
+- `systems/spawn.rs`: NpcSkills::default() on spawn, overrides for save restore
+
+## UI
+
+- Inspector Skills tab: progress bars 0-9999, color-coded (gray <2500, white 2500-7499, green >=7500)
+- Roster Prof column: top skill value, sortable
+- Effect descriptions show current multiplier
 
 ## Testing
 
-- `tests/skills_progression.rs`: verifies farming/combat/dodge proficiency increases under expected actions
-- `tests/skills_effects.rs`: higher farm proficiency yields faster output than baseline; higher combat proficiency yields better duel outcome; higher dodge proficiency reduces projectile hits
-- Regression: ensure no-skill baseline behavior remains close to current gameplay
+- proficiency_mult(0) == 1.0
+- proficiency_mult(100) == 2.0
+- proficiency_mult(9999) ~= 100.99
+- No clamp test (values above 9999 would give higher mult, but skill gain caps at 9999)
+- Dodge chance caps at 50% regardless of prof value

--- a/rust/src/constants/mod.rs
+++ b/rust/src/constants/mod.rs
@@ -327,8 +327,8 @@ pub const MAX_SQUADS: usize = 10;
 pub const FARMING_SKILL_RATE: f32 = 0.02;
 pub const COMBAT_SKILL_RATE: f32 = 1.0;
 pub const DODGE_SKILL_RATE: f32 = 0.5;
-pub const MAX_PROFICIENCY: f32 = 100.0;
-pub const DODGE_PROF_MAX_CHANCE: f32 = 0.25;
+pub const MAX_PROFICIENCY: f32 = 9999.0;
+pub const DODGE_PROF_MAX_CHANCE: f32 = 0.50;
 
 /// Default real-time seconds between AI decisions.
 pub const DEFAULT_AI_INTERVAL: f32 = 5.0;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -447,6 +447,7 @@ pub fn build_app(app: &mut App) {
         .register_type::<components::HasEnergy>()
         .register_type::<components::NpcEquipment>()
         .register_type::<components::NpcStats>()
+        .register_type::<components::NpcSkills>()
         .register_type::<components::LastHitBy>()
         .register_type::<components::Building>()
         .register_type::<components::FarmReadyMarker>()

--- a/rust/src/systems/health/mod.rs
+++ b/rust/src/systems/health/mod.rs
@@ -224,6 +224,7 @@ pub fn death_system(
     squad_state: Res<SquadState>,
     mut town_access: crate::systemparams::TownAccess,
     config: Res<CombatConfig>,
+    mut skills_q: Query<&mut crate::components::NpcSkills>,
     mut intents: ResMut<crate::resources::PathRequestQueue>,
     mut ui_state: ResMut<crate::resources::UiState>,
 ) {
@@ -636,6 +637,11 @@ pub fn death_system(
                 } else {
                     (0, 100)
                 };
+                // Grant combat proficiency on kill
+                if let Ok(mut sk) = skills_q.get_mut(k_entity) {
+                    sk.combat = (sk.combat + crate::constants::COMBAT_SKILL_RATE)
+                        .min(crate::constants::MAX_PROFICIENCY);
+                }
                 let old_level = level_from_xp(old_xp);
                 let new_level = level_from_xp(new_xp);
 
@@ -656,6 +662,7 @@ pub fn death_system(
                         .get(k_entity)
                         .map(|eq| (eq.total_weapon_bonus(), eq.total_armor_bonus()))
                         .unwrap_or((0.0, 0.0));
+                    let prof_c = skills_q.get(k_entity).map(|s| s.combat).unwrap_or(0.0);
                     let new_cached = resolve_combat_stats(
                         killer.job,
                         attack_type,
@@ -666,6 +673,7 @@ pub fn death_system(
                         &town_access.upgrade_levels(killer.town_idx),
                         wb,
                         ab,
+                        prof_c,
                     );
                     let new_speed = new_cached.speed;
                     let new_max = new_cached.max_health;

--- a/rust/src/systems/spawn.rs
+++ b/rust/src/systems/spawn.rs
@@ -124,6 +124,7 @@ pub fn materialize_npc(
         .unwrap_or_else(|| generate_personality(idx));
     let level = overrides.level.unwrap_or(0);
 
+    let prof_combat = overrides.skills.as_ref().map(|s| s.combat).unwrap_or(0.0);
     let cached = resolve_combat_stats(
         job,
         attack_type,
@@ -134,6 +135,7 @@ pub fn materialize_npc(
         town_levels,
         overrides.equipment.total_weapon_bonus(),
         overrides.equipment.total_armor_bonus(),
+        prof_combat,
     );
 
     // GPU init

--- a/rust/src/systems/stats/mod.rs
+++ b/rust/src/systems/stats/mod.rs
@@ -722,6 +722,7 @@ pub fn resolve_combat_stats(
     town_levels: &[u8],
     weapon_bonus: f32,
     armor_bonus: f32,
+    prof_combat: f32,
 ) -> CachedStats {
     let def = npc_def(job);
     let default_atk = config
@@ -747,14 +748,16 @@ pub fn resolve_combat_stats(
     let stamina_mult = reg.stat_mult(town, cat, UpgradeStatKind::Stamina);
     let hp_regen_level = reg.stat_level(town, cat, UpgradeStatKind::HpRegen) as f32;
 
+    let prof_mult = proficiency_mult(prof_combat);
     CachedStats {
         damage: def.base_damage
             * upgrade_dmg
             * trait_mods.damage
             * level_mult
-            * (1.0 + weapon_bonus),
+            * (1.0 + weapon_bonus)
+            * prof_mult,
         range: atk_base.range * upgrade_range * trait_mods.range,
-        cooldown: atk_base.cooldown * cooldown_mult * trait_mods.cooldown,
+        cooldown: atk_base.cooldown * cooldown_mult * trait_mods.cooldown / prof_mult,
         projectile_speed: atk_base.projectile_speed * upgrade_proj_speed,
         projectile_lifetime: atk_base.projectile_lifetime * upgrade_proj_life,
         max_health: def.base_hp * upgrade_hp * trait_mods.hp * level_mult * (1.0 + armor_bonus),
@@ -777,6 +780,7 @@ pub fn re_resolve_npc_stats(
     personality: &Personality,
     config: &CombatConfig,
     town_levels: &[u8],
+    prof_combat: f32,
     cached_stats_q: &mut Query<&mut CachedStats>,
     speed_q: &mut Query<&mut crate::components::Speed>,
     health_q: &mut Query<&mut crate::components::Health, Without<crate::components::Building>>,
@@ -796,6 +800,7 @@ pub fn re_resolve_npc_stats(
         town_levels,
         equipment.total_weapon_bonus(),
         equipment.total_armor_bonus(),
+        prof_combat,
     );
     let new_speed = new_cached.speed;
     let new_max = new_cached.max_health;
@@ -843,6 +848,7 @@ pub fn process_upgrades_system(
     attack_type_q: Query<&crate::components::BaseAttackType>,
     personality_q: Query<&crate::components::Personality>,
     equipment_q: Query<&crate::components::NpcEquipment>,
+    skills_q: Query<&crate::components::NpcSkills>,
 ) {
     let count = upgrade_count();
     for msg in queue.read() {
@@ -942,6 +948,7 @@ pub fn process_upgrades_system(
                 .get(entity)
                 .map(|eq| (eq.total_weapon_bonus(), eq.total_armor_bonus()))
                 .unwrap_or((0.0, 0.0));
+            let prof_c = skills_q.get(entity).map(|s| s.combat).unwrap_or(0.0);
             let new_cached = resolve_combat_stats(
                 npc.job,
                 atk_type,
@@ -952,6 +959,7 @@ pub fn process_upgrades_system(
                 &town_levels,
                 wb,
                 ab,
+                prof_c,
             );
             let new_speed = new_cached.speed;
             let new_max = new_cached.max_health;
@@ -1008,8 +1016,9 @@ pub fn process_equip_system(
     mut town_access: crate::systemparams::TownAccess,
     npc_stats_q: Query<&crate::components::NpcStats>,
     mut gpu_updates: MessageWriter<GpuUpdateMsg>,
+    skills_q: Query<&crate::components::NpcSkills>,
 ) {
-    // Equip: TownEquipment → NpcEquipment
+    // Equip: TownEquipment -> NpcEquipment
     for msg in equip_msgs.read() {
         let item = {
             let Some(mut eq) = town_access.equipment_mut(msg.town_idx as i32) else {
@@ -1058,6 +1067,10 @@ pub fn process_equip_system(
             .map(|s| level_from_xp(s.xp))
             .unwrap_or(0);
         let tl = town_access.upgrade_levels(town_id.0);
+        let prof_c = skills_q
+            .get(msg.npc_entity)
+            .map(|s| s.combat)
+            .unwrap_or(0.0);
         re_resolve_npc_stats(
             msg.npc_entity,
             slot_idx,
@@ -1069,6 +1082,7 @@ pub fn process_equip_system(
             pers,
             &config,
             &tl,
+            prof_c,
             &mut cached_stats_q,
             &mut speed_q,
             &mut health_q,
@@ -1109,6 +1123,10 @@ pub fn process_equip_system(
             .map(|s| level_from_xp(s.xp))
             .unwrap_or(0);
         let tl = town_access.upgrade_levels(town_id.0);
+        let prof_c = skills_q
+            .get(msg.npc_entity)
+            .map(|s| s.combat)
+            .unwrap_or(0.0);
         re_resolve_npc_stats(
             msg.npc_entity,
             slot_idx,
@@ -1120,6 +1138,7 @@ pub fn process_equip_system(
             pers,
             &config,
             &tl,
+            prof_c,
             &mut cached_stats_q,
             &mut speed_q,
             &mut health_q,

--- a/rust/src/systems/stats/mod.rs
+++ b/rust/src/systems/stats/mod.rs
@@ -700,11 +700,10 @@ fn is_combat_upgrade(idx: usize) -> bool {
     UPGRADES.nodes[idx].is_combat_stat
 }
 
-/// Convert proficiency (0..MAX_PROFICIENCY) to a multiplier.
-/// 0 = 1.0x, MAX/2 = 1.25x, MAX = 1.5x.
+/// Disgaea-style proficiency multiplier. Unclamped, linear.
+/// 0 = 1.0x, 100 = 2.0x, 1000 = 11x, 9999 = ~101x.
 pub fn proficiency_mult(value: f32) -> f32 {
-    use crate::constants::MAX_PROFICIENCY;
-    1.0 + (value.clamp(0.0, MAX_PROFICIENCY) / MAX_PROFICIENCY) * 0.5
+    1.0 + value * 0.01
 }
 
 // ============================================================================

--- a/rust/src/systems/stats/mod.rs
+++ b/rust/src/systems/stats/mod.rs
@@ -700,10 +700,11 @@ fn is_combat_upgrade(idx: usize) -> bool {
     UPGRADES.nodes[idx].is_combat_stat
 }
 
-/// Convert proficiency (0-100) to a multiplier.
-/// 0 = 1.0x (no bonus), 50 = 1.25x, 100 = 1.5x.
+/// Convert proficiency (0..MAX_PROFICIENCY) to a multiplier.
+/// 0 = 1.0x, MAX/2 = 1.25x, MAX = 1.5x.
 pub fn proficiency_mult(value: f32) -> f32 {
-    1.0 + (value.clamp(0.0, 100.0) / 100.0) * 0.5
+    use crate::constants::MAX_PROFICIENCY;
+    1.0 + (value.clamp(0.0, MAX_PROFICIENCY) / MAX_PROFICIENCY) * 0.5
 }
 
 // ============================================================================

--- a/rust/src/systems/stats/mod.rs
+++ b/rust/src/systems/stats/mod.rs
@@ -700,7 +700,7 @@ fn is_combat_upgrade(idx: usize) -> bool {
     UPGRADES.nodes[idx].is_combat_stat
 }
 
-/// Disgaea-style proficiency multiplier. Unclamped, linear.
+/// Unclamped linear proficiency multiplier.
 /// 0 = 1.0x, 100 = 2.0x, 1000 = 11x, 9999 = ~101x.
 pub fn proficiency_mult(value: f32) -> f32 {
     1.0 + value * 0.01

--- a/rust/src/systems/stats/tests.rs
+++ b/rust/src/systems/stats/tests.rs
@@ -257,6 +257,7 @@ fn resolve_combat_stats_archer_defaults() {
         &upgrades,
         0.0,
         0.0,
+        0.0,
     );
     let def = npc_def(Job::Archer);
     // With no upgrades, no level, no equipment, no traits:
@@ -297,6 +298,7 @@ fn resolve_combat_stats_level_scaling() {
         &upgrades,
         0.0,
         0.0,
+        0.0,
     );
     let stats_lv10 = resolve_combat_stats(
         Job::Archer,
@@ -306,6 +308,7 @@ fn resolve_combat_stats_level_scaling() {
         &personality,
         &config,
         &upgrades,
+        0.0,
         0.0,
         0.0,
     );
@@ -334,6 +337,7 @@ fn resolve_combat_stats_equipment_bonus() {
         &upgrades,
         0.0,
         0.0,
+        0.0,
     );
     let with_weapon = resolve_combat_stats(
         Job::Archer,
@@ -344,6 +348,7 @@ fn resolve_combat_stats_equipment_bonus() {
         &config,
         &upgrades,
         0.5,
+        0.0,
         0.0,
     );
     let with_armor = resolve_combat_stats(
@@ -356,6 +361,7 @@ fn resolve_combat_stats_equipment_bonus() {
         &upgrades,
         0.0,
         0.5,
+        0.0,
     );
     // 50% weapon bonus → 1.5x damage
     assert!((with_weapon.damage / base.damage - 1.5).abs() < 0.01);
@@ -382,6 +388,7 @@ fn resolve_combat_stats_berserk_from_ferocity() {
         &personality,
         &config,
         &upgrades,
+        0.0,
         0.0,
         0.0,
     );
@@ -412,6 +419,7 @@ fn resolve_combat_stats_timid_negative_berserk() {
         &personality,
         &config,
         &upgrades,
+        0.0,
         0.0,
         0.0,
     );

--- a/rust/src/systems/stats/tests.rs
+++ b/rust/src/systems/stats/tests.rs
@@ -450,7 +450,7 @@ fn resolve_tower_instance_stats_level_scales() {
     assert!(stats_lv10.range > stats_lv0.range);
 }
 
-// -- proficiency_mult (Disgaea-style, unclamped) -------------------------
+// -- proficiency_mult (unclamped linear) ----------------------------------
 
 #[test]
 fn proficiency_mult_zero_is_one() {

--- a/rust/src/systems/stats/tests.rs
+++ b/rust/src/systems/stats/tests.rs
@@ -450,7 +450,7 @@ fn resolve_tower_instance_stats_level_scales() {
     assert!(stats_lv10.range > stats_lv0.range);
 }
 
-// -- proficiency_mult ----------------------------------------------------
+// -- proficiency_mult (Disgaea-style, unclamped) -------------------------
 
 #[test]
 fn proficiency_mult_zero_is_one() {
@@ -458,18 +458,18 @@ fn proficiency_mult_zero_is_one() {
 }
 
 #[test]
-fn proficiency_mult_fifty_is_one_point_two_five() {
-    assert!((proficiency_mult(50.0) - 1.25).abs() < 0.001);
+fn proficiency_mult_hundred_is_two() {
+    assert!((proficiency_mult(100.0) - 2.0).abs() < 0.001);
 }
 
 #[test]
-fn proficiency_mult_hundred_is_one_point_five() {
-    assert!((proficiency_mult(100.0) - 1.5).abs() < f32::EPSILON);
+fn proficiency_mult_1000_is_eleven() {
+    assert!((proficiency_mult(1000.0) - 11.0).abs() < 0.001);
 }
 
 #[test]
-fn proficiency_mult_clamps_above_100() {
-    assert!((proficiency_mult(200.0) - 1.5).abs() < f32::EPSILON);
+fn proficiency_mult_9999_is_godlike() {
+    assert!((proficiency_mult(9999.0) - 100.99).abs() < 0.01);
 }
 
 // -- UpgradeRegistry::stat_mult ------------------------------------------


### PR DESCRIPTION
## Summary

Wires combat proficiency into the stat reconcile pipeline, grants it on kills, and implements unclamped linear scaling (MAX=9999, ~101x at max).

## Changes

- `stats/mod.rs`: `resolve_combat_stats` takes `prof_combat: f32`. Applies `proficiency_mult()` to damage and inverse to cooldown. `re_resolve_npc_stats`, `process_upgrades_system`, `process_equip_system` all pass prof_combat from NpcSkills query.
- `spawn.rs`: passes `overrides.skills.combat` (or 0.0 for fresh spawns)
- `health/mod.rs`: grants `COMBAT_SKILL_RATE` (1.0) combat proficiency per kill, capped at `MAX_PROFICIENCY` (9999.0). Level-up re-resolve includes combat proficiency.
- `constants/mod.rs`: MAX_PROFICIENCY 100 -> 9999, DODGE_PROF_MAX_CHANCE 0.25 -> 0.50
- `stats/mod.rs`: proficiency_mult changed to unclamped linear: `1.0 + value * 0.01`
- `docs/specs/npc-skills.md`: rewritten for unclamped scaling
- `world.rs`: tower pathing uses registry-driven `def.is_tower` loop

## Scaling (unclamped linear)

| Prof  | Multiplier | Feel           |
|-------|-----------|----------------|
| 0     | 1.0x      | Fresh spawn    |
| 100   | 2.0x      | Experienced    |
| 1000  | 11.0x     | Elite          |
| 5000  | 51.0x     | Legendary      |
| 9999  | 101.0x    | Godlike        |

## Compliance

- **k8s.md**: NpcSkills is CR instance state. Stats reconciled via controller pattern. Tower pathing uses registry.
- **authority.md**: CPU-only. No GPU readback changes.
- **performance.md**: skills_q.get() is O(1) per entity in existing reconcile paths. No new iteration.

Closes #111