### PR TITLE
feat: dodge proficiency -- personal projectile miss chance + skill gain

### DIFF
--- a/docs/specs/npc-skills.md
+++ b/docs/specs/npc-skills.md
@@ -46,9 +46,9 @@ No clamp on the multiplier. MAX_PROFICIENCY (9999) only caps the proficiency val
 
 - **Combat**: `damage *= proficiency_mult(combat)`, `cooldown /= proficiency_mult(combat)`
 - **Farming**: `growth_rate *= proficiency_mult(farming)` for tended farms
-- **Dodge**: miss chance = `min(dodge_prof * 0.0025, 0.50)` -- hard cap at 50% dodge chance (can't be invincible)
+- **Dodge**: miss chance = `1.0 - 1.0 / proficiency_mult(dodge)`. At 0: 0%, 100: 50%, 1000: 91%, 9999: 99%.
 
-Dodge is the exception: the proficiency_mult formula applies to damage/farming scaling, but dodge chance uses a separate linear formula with a hard cap since >100% dodge would break combat.
+All three skills use the same proficiency_mult function. Dodge converts the multiplier to a probability via `1 - 1/mult`, which naturally approaches but never reaches 100%.
 
 ## Skill gain rates
 
@@ -65,7 +65,6 @@ pub const FARMING_SKILL_RATE: f32 = 0.02;
 pub const COMBAT_SKILL_RATE: f32 = 1.0;
 pub const DODGE_SKILL_RATE: f32 = 0.5;
 pub const MAX_PROFICIENCY: f32 = 9999.0;
-pub const DODGE_PROF_MAX_CHANCE: f32 = 0.50;
 ```
 
 ## System integration
@@ -88,4 +87,4 @@ pub const DODGE_PROF_MAX_CHANCE: f32 = 0.50;
 - proficiency_mult(100) == 2.0
 - proficiency_mult(9999) ~= 100.99
 - No clamp test (values above 9999 would give higher mult, but skill gain caps at 9999)
-- Dodge chance caps at 50% regardless of prof value
+- Dodge chance at prof 100 = 50%, prof 1000 = 91%, prof 9999 = 99% (via 1 - 1/mult)

--- a/rust/src/constants/mod.rs
+++ b/rust/src/constants/mod.rs
@@ -328,7 +328,6 @@ pub const FARMING_SKILL_RATE: f32 = 0.02;
 pub const COMBAT_SKILL_RATE: f32 = 1.0;
 pub const DODGE_SKILL_RATE: f32 = 0.5;
 pub const MAX_PROFICIENCY: f32 = 9999.0;
-pub const DODGE_PROF_MAX_CHANCE: f32 = 0.50;
 
 /// Default real-time seconds between AI decisions.
 pub const DEFAULT_AI_INTERVAL: f32 = 5.0;

--- a/rust/src/systems/combat.rs
+++ b/rust/src/systems/combat.rs
@@ -489,6 +489,8 @@ pub fn process_proj_hits(
     entity_map: Res<crate::resources::EntityMap>,
     gpu_state: Res<GpuReadState>,
     grid: Res<WorldGrid>,
+    mut skills_q: Query<&mut NpcSkills>,
+    town_access: crate::systemparams::TownAccess,
 ) {
     use rand::Rng;
     let mut rng = rand::rng();
@@ -526,6 +528,29 @@ pub fn process_proj_hits(
                         proj_updates
                             .write(ProjGpuUpdateMsg(ProjGpuUpdate::Deactivate { idx: slot }));
                         continue;
+                    }
+                }
+
+                // Dodge proficiency: personal miss chance based on target's dodge skill.
+                // Only active if dodge_unlocked upgrade purchased for the target's town.
+                if let Some(npc) = entity_map.get_npc(ti) {
+                    let levels = town_access.upgrade_levels(npc.town_idx);
+                    if crate::systems::stats::dodge_unlocked(&levels) {
+                        if let Ok(mut skills) = skills_q.get_mut(npc.entity) {
+                            let dodge_chance = skills.dodge
+                                / (crate::constants::MAX_PROFICIENCY
+                                    / crate::constants::DODGE_PROF_MAX_CHANCE);
+                            if rng.random_range(0.0..1.0_f32) < dodge_chance {
+                                // Dodged -- grant dodge proficiency
+                                skills.dodge = (skills.dodge + crate::constants::DODGE_SKILL_RATE)
+                                    .min(crate::constants::MAX_PROFICIENCY);
+                                proj_alloc.free(slot);
+                                proj_updates.write(ProjGpuUpdateMsg(ProjGpuUpdate::Deactivate {
+                                    idx: slot,
+                                }));
+                                continue;
+                            }
+                        }
                     }
                 }
 
@@ -1285,6 +1310,7 @@ mod tests {
         app.insert_resource(crate::resources::EntityMap::default());
         app.insert_resource(crate::resources::GpuReadState::default());
         app.insert_resource(crate::world::WorldGrid::default());
+        app.insert_resource(crate::resources::TownIndex::default());
 
         let slot = app
             .world_mut()

--- a/rust/src/systems/combat.rs
+++ b/rust/src/systems/combat.rs
@@ -532,14 +532,14 @@ pub fn process_proj_hits(
                 }
 
                 // Dodge proficiency: personal miss chance based on target's dodge skill.
-                // Only active if dodge_unlocked upgrade purchased for the target's town.
+                // Uses same proficiency_mult as combat/farming: dodge_chance = 1 - 1/mult.
+                // At prof 0: 0%, 100: 50%, 1000: 91%, 9999: 99%.
                 if let Some(npc) = entity_map.get_npc(ti) {
                     let levels = town_access.upgrade_levels(npc.town_idx);
                     if crate::systems::stats::dodge_unlocked(&levels) {
                         if let Ok(mut skills) = skills_q.get_mut(npc.entity) {
-                            let dodge_chance = skills.dodge
-                                / (crate::constants::MAX_PROFICIENCY
-                                    / crate::constants::DODGE_PROF_MAX_CHANCE);
+                            let mult = crate::systems::stats::proficiency_mult(skills.dodge);
+                            let dodge_chance = 1.0 - 1.0 / mult;
                             if rng.random_range(0.0..1.0_f32) < dodge_chance {
                                 // Dodged -- grant dodge proficiency
                                 skills.dodge = (skills.dodge + crate::constants::DODGE_SKILL_RATE)


### PR DESCRIPTION
## Summary

Dodge proficiency gives experienced NPCs a personal projectile miss chance, using the same unclamped proficiency_mult curve as combat and farming.

## Changes

- `combat.rs`: After forest cover miss check, rolls dodge chance using `1.0 - 1.0 / proficiency_mult(dodge)`. Same curve as combat/farming -- at prof 100: 50% dodge, 1000: 91%, 9999: 99%.
- `combat.rs`: Successful dodges grant +DODGE_SKILL_RATE (0.5) proficiency, capped at MAX_PROFICIENCY (9999).
- `constants/mod.rs`: Removed DODGE_PROF_MAX_CHANCE constant (no longer needed -- dodge uses proficiency_mult curve directly).
- `docs/specs/npc-skills.md`: Updated dodge section to use `1 - 1/mult` formula.

## Scaling (unclamped, same curve as combat/farming)

| Prof  | Dodge chance | Feel           |
|-------|-------------|----------------|
| 0     | 0%          | Fresh spawn    |
| 100   | 50%         | Experienced    |
| 500   | 83%         | Veteran        |
| 1000  | 91%         | Elite          |
| 5000  | 98%         | Legendary      |
| 9999  | 99%         | Godlike        |

## Compliance

- **k8s.md**: NpcSkills is CR instance state. No new entity types.
- **authority.md**: CPU-only. EntityMap keyed lookup for NPC, no GPU readback.
- **performance.md**: O(1) per projectile hit (EntityMap lookup + upgrade check + rng roll). Not a hot path.

Closes #113