### PR TITLE
feat: skills UI -- inspector display + roster Prof column

### DIFF
--- a/rust/src/ui/game_hud.rs
+++ b/rust/src/ui/game_hud.rs
@@ -1836,9 +1836,10 @@ fn inspector_content(
             let bar_w = 180.0f32;
             let bar_h = 12.0f32;
 
-            let skill_entries: &[(&str, f32, String)] = &[
+            // Build all possible entries
+            let all_entries: Vec<(&str, f32, String)> = vec![
                 (
-                    "Farming",
+                    "farming",
                     skills.farming,
                     format!(
                         "+{:.2}/hr tending. {:.2}x growth rate.",
@@ -1847,7 +1848,7 @@ fn inspector_content(
                     ),
                 ),
                 (
-                    "Combat",
+                    "combat",
                     skills.combat,
                     format!(
                         "+{:.1}/kill. {:.2}x damage, {:.2}x cooldown.",
@@ -1857,7 +1858,7 @@ fn inspector_content(
                     ),
                 ),
                 (
-                    "Dodge",
+                    "dodge",
                     skills.dodge,
                     format!(
                         "+{:.1}/dodge. {:.1}% miss chance.",
@@ -1867,7 +1868,26 @@ fn inspector_content(
                 ),
             ];
 
-            for &(name, value, ref desc) in skill_entries {
+            // Filter to job-relevant skills only
+            let relevant: &[&str] = match npc_job.unwrap_or(Job::Farmer) {
+                Job::Farmer => &["farming"],
+                Job::Archer | Job::Crossbow | Job::Fighter | Job::Raider => &["combat", "dodge"],
+                _ => &[],
+            };
+            let skill_entries: Vec<_> = all_entries
+                .into_iter()
+                .filter(|(name, _, _)| relevant.contains(name))
+                .collect();
+
+            if skill_entries.is_empty() {
+                ui.label(
+                    egui::RichText::new("No skills for this job yet.")
+                        .color(egui::Color32::from_rgb(120, 120, 120)),
+                );
+            }
+
+            for (name, value, desc) in &skill_entries {
+                let value = *value;
                 let color = super::skill_prof_color(value);
                 ui.horizontal(|ui| {
                     ui.label(

--- a/rust/src/ui/game_hud.rs
+++ b/rust/src/ui/game_hud.rs
@@ -1857,15 +1857,15 @@ fn inspector_content(
                         1.0 / crate::systems::stats::proficiency_mult(skills.combat),
                     ),
                 ),
-                (
-                    "dodge",
-                    skills.dodge,
+                ("dodge", skills.dodge, {
+                    let dodge_mult = crate::systems::stats::proficiency_mult(skills.dodge);
+                    let dodge_pct = (1.0 - 1.0 / dodge_mult) * 100.0;
                     format!(
                         "+{:.1}/dodge. {:.1}% miss chance.",
                         crate::constants::DODGE_SKILL_RATE,
-                        crate::constants::DODGE_PROF_MAX_CHANCE * skills.dodge / max * 100.0,
-                    ),
-                ),
+                        dodge_pct,
+                    )
+                }),
             ];
 
             // Filter to job-relevant skills only

--- a/rust/src/ui/game_hud.rs
+++ b/rust/src/ui/game_hud.rs
@@ -1755,26 +1755,15 @@ fn inspector_content(
             }
             // Show non-zero skill proficiencies
             if let Ok(skills) = bld_data.skills_q.get(npc.entity) {
-                let mut parts: Vec<String> = Vec::new();
-                let skill_color = |v: f32| -> egui::Color32 {
-                    if v >= 75.0 {
-                        egui::Color32::from_rgb(100, 220, 100)
-                    } else if v >= 25.0 {
-                        egui::Color32::WHITE
-                    } else {
-                        egui::Color32::GRAY
-                    }
-                };
-                for (name, val) in [
+                let entries: Vec<_> = [
                     ("Farm", skills.farming),
                     ("Combat", skills.combat),
                     ("Dodge", skills.dodge),
-                ] {
-                    if val > 0.0 {
-                        parts.push(format!("{} {}", name, val as i32));
-                    }
-                }
-                if !parts.is_empty() {
+                ]
+                .into_iter()
+                .filter(|(_, v)| *v > 0.0)
+                .collect();
+                if !entries.is_empty() {
                     let mut job = egui::text::LayoutJob::default();
                     job.append(
                         "Skills: ",
@@ -1784,15 +1773,7 @@ fn inspector_content(
                             ..Default::default()
                         },
                     );
-                    for (i, (name, val)) in [
-                        ("Farm", skills.farming),
-                        ("Combat", skills.combat),
-                        ("Dodge", skills.dodge),
-                    ]
-                    .iter()
-                    .filter(|(_, v)| *v > 0.0)
-                    .enumerate()
-                    {
+                    for (i, (name, val)) in entries.iter().enumerate() {
                         if i > 0 {
                             job.append("  ", 0.0, egui::TextFormat::default());
                         }
@@ -1800,7 +1781,7 @@ fn inspector_content(
                             &format!("{} {}", name, *val as i32),
                             0.0,
                             egui::TextFormat {
-                                color: skill_color(*val),
+                                color: super::skill_prof_color(*val),
                                 ..Default::default()
                             },
                         );

--- a/rust/src/ui/game_hud.rs
+++ b/rust/src/ui/game_hud.rs
@@ -773,6 +773,7 @@ pub enum InspectorNpcTab {
     #[default]
     Overview,
     Loadout,
+    Skills,
     Economy,
     Log,
 }
@@ -1696,12 +1697,14 @@ fn inspector_content(
     ui.horizontal_wrapped(|ui| {
         ui.selectable_value(npc_tab, InspectorNpcTab::Overview, "Overview");
         ui.selectable_value(npc_tab, InspectorNpcTab::Loadout, "Loadout");
+        ui.selectable_value(npc_tab, InspectorNpcTab::Skills, "Skills");
         ui.selectable_value(npc_tab, InspectorNpcTab::Economy, "Economy");
         ui.selectable_value(npc_tab, InspectorNpcTab::Log, "Log");
     });
     ui.separator();
     let show_overview = *npc_tab == InspectorNpcTab::Overview;
     let show_loadout = *npc_tab == InspectorNpcTab::Loadout;
+    let show_skills = *npc_tab == InspectorNpcTab::Skills;
     let show_economy = *npc_tab == InspectorNpcTab::Economy;
     let show_log = *npc_tab == InspectorNpcTab::Log;
 
@@ -1751,42 +1754,6 @@ fn inspector_content(
                         format!("Trait: {}", trait_str),
                         catalog.0.get("npc_trait").unwrap_or(&""),
                     );
-                }
-            }
-            // Show non-zero skill proficiencies
-            if let Ok(skills) = bld_data.skills_q.get(npc.entity) {
-                let entries: Vec<_> = [
-                    ("Farm", skills.farming),
-                    ("Combat", skills.combat),
-                    ("Dodge", skills.dodge),
-                ]
-                .into_iter()
-                .filter(|(_, v)| *v > 0.0)
-                .collect();
-                if !entries.is_empty() {
-                    let mut job = egui::text::LayoutJob::default();
-                    job.append(
-                        "Skills: ",
-                        0.0,
-                        egui::TextFormat {
-                            color: egui::Color32::WHITE,
-                            ..Default::default()
-                        },
-                    );
-                    for (i, (name, val)) in entries.iter().enumerate() {
-                        if i > 0 {
-                            job.append("  ", 0.0, egui::TextFormat::default());
-                        }
-                        job.append(
-                            &format!("{} {}", name, *val as i32),
-                            0.0,
-                            egui::TextFormat {
-                                color: super::skill_prof_color(*val),
-                                ..Default::default()
-                            },
-                        );
-                    }
-                    ui.label(job);
                 }
             }
         }
@@ -1854,6 +1821,83 @@ fn inspector_content(
                 "Dmg: {:.0}  Rng: {:.0}  CD: {:.1}s  Spd: {:.0}",
                 stats.damage, stats.range, stats.cooldown, stats.speed
             ));
+        }
+    }
+
+    // Skills tab -- dedicated proficiency display with bars and effect descriptions
+    if show_skills {
+        if let Some(npc) = bld_data.entity_map.get_npc(idx) {
+            let skills = bld_data
+                .skills_q
+                .get(npc.entity)
+                .cloned()
+                .unwrap_or_default();
+            let max = crate::constants::MAX_PROFICIENCY;
+            let bar_w = 180.0f32;
+            let bar_h = 12.0f32;
+
+            let skill_entries: &[(&str, f32, String)] = &[
+                (
+                    "Farming",
+                    skills.farming,
+                    format!(
+                        "+{:.2}/hr tending. {:.2}x growth rate.",
+                        crate::constants::FARMING_SKILL_RATE,
+                        crate::systems::stats::proficiency_mult(skills.farming),
+                    ),
+                ),
+                (
+                    "Combat",
+                    skills.combat,
+                    format!(
+                        "+{:.1}/kill. {:.2}x damage, {:.2}x cooldown.",
+                        crate::constants::COMBAT_SKILL_RATE,
+                        crate::systems::stats::proficiency_mult(skills.combat),
+                        1.0 / crate::systems::stats::proficiency_mult(skills.combat),
+                    ),
+                ),
+                (
+                    "Dodge",
+                    skills.dodge,
+                    format!(
+                        "+{:.1}/dodge. {:.1}% miss chance.",
+                        crate::constants::DODGE_SKILL_RATE,
+                        crate::constants::DODGE_PROF_MAX_CHANCE * skills.dodge / max * 100.0,
+                    ),
+                ),
+            ];
+
+            for &(name, value, ref desc) in skill_entries {
+                let color = super::skill_prof_color(value);
+                ui.horizontal(|ui| {
+                    ui.label(
+                        egui::RichText::new(format!("{:<8}", name))
+                            .color(egui::Color32::WHITE)
+                            .strong(),
+                    );
+                    // Progress bar
+                    let (rect, _) =
+                        ui.allocate_exact_size(egui::vec2(bar_w, bar_h), egui::Sense::hover());
+                    let painter = ui.painter();
+                    painter.rect_filled(rect, 2.0, egui::Color32::from_rgb(40, 40, 45));
+                    let fill_w = (value / max).clamp(0.0, 1.0) * bar_w;
+                    if fill_w > 0.5 {
+                        let fill_rect =
+                            egui::Rect::from_min_size(rect.min, egui::vec2(fill_w, bar_h));
+                        painter.rect_filled(fill_rect, 2.0, color);
+                    }
+                    ui.label(
+                        egui::RichText::new(format!("{} / {}", value as i32, max as i32))
+                            .color(color),
+                    );
+                });
+                ui.label(
+                    egui::RichText::new(format!("  {}", desc))
+                        .color(egui::Color32::from_rgb(160, 160, 160))
+                        .small(),
+                );
+                ui.add_space(4.0);
+            }
         }
     }
 

--- a/rust/src/ui/game_hud.rs
+++ b/rust/src/ui/game_hud.rs
@@ -696,6 +696,7 @@ pub struct BuildingInspectorData<'w, 's> {
     pub combat_state_q: Query<'w, 's, &'static CombatState>,
     pub energy_q: Query<'w, 's, &'static Energy>,
     pub personality_q: Query<'w, 's, &'static Personality>,
+    pub skills_q: Query<'w, 's, &'static NpcSkills>,
     pub home_q: Query<'w, 's, &'static Home>,
     pub work_state_q: Query<'w, 's, &'static NpcWorkState>,
     pub equipment_q: Query<'w, 's, &'static NpcEquipment>,
@@ -1750,6 +1751,61 @@ fn inspector_content(
                         format!("Trait: {}", trait_str),
                         catalog.0.get("npc_trait").unwrap_or(&""),
                     );
+                }
+            }
+            // Show non-zero skill proficiencies
+            if let Ok(skills) = bld_data.skills_q.get(npc.entity) {
+                let mut parts: Vec<String> = Vec::new();
+                let skill_color = |v: f32| -> egui::Color32 {
+                    if v >= 75.0 {
+                        egui::Color32::from_rgb(100, 220, 100)
+                    } else if v >= 25.0 {
+                        egui::Color32::WHITE
+                    } else {
+                        egui::Color32::GRAY
+                    }
+                };
+                for (name, val) in [
+                    ("Farm", skills.farming),
+                    ("Combat", skills.combat),
+                    ("Dodge", skills.dodge),
+                ] {
+                    if val > 0.0 {
+                        parts.push(format!("{} {}", name, val as i32));
+                    }
+                }
+                if !parts.is_empty() {
+                    let mut job = egui::text::LayoutJob::default();
+                    job.append(
+                        "Skills: ",
+                        0.0,
+                        egui::TextFormat {
+                            color: egui::Color32::WHITE,
+                            ..Default::default()
+                        },
+                    );
+                    for (i, (name, val)) in [
+                        ("Farm", skills.farming),
+                        ("Combat", skills.combat),
+                        ("Dodge", skills.dodge),
+                    ]
+                    .iter()
+                    .filter(|(_, v)| *v > 0.0)
+                    .enumerate()
+                    {
+                        if i > 0 {
+                            job.append("  ", 0.0, egui::TextFormat::default());
+                        }
+                        job.append(
+                            &format!("{} {}", name, *val as i32),
+                            0.0,
+                            egui::TextFormat {
+                                color: skill_color(*val),
+                                ..Default::default()
+                            },
+                        );
+                    }
+                    ui.label(job);
                 }
             }
         }

--- a/rust/src/ui/mod.rs
+++ b/rust/src/ui/mod.rs
@@ -1967,6 +1967,17 @@ fn build_place_click_system(
     sync_food!();
 }
 
+/// Skill proficiency color: gray (<25), white (25-74), green (>=75).
+pub(crate) fn skill_prof_color(value: f32) -> egui::Color32 {
+    if value >= 75.0 {
+        egui::Color32::from_rgb(100, 220, 100)
+    } else if value >= 25.0 {
+        egui::Color32::WHITE
+    } else {
+        egui::Color32::GRAY
+    }
+}
+
 /// Marker component for slot indicator sprite entities.
 #[derive(Component)]
 pub(crate) struct SlotIndicator;

--- a/rust/src/ui/mod.rs
+++ b/rust/src/ui/mod.rs
@@ -1967,11 +1967,11 @@ fn build_place_click_system(
     sync_food!();
 }
 
-/// Skill proficiency color: gray (<25), white (25-74), green (>=75).
+/// Skill proficiency color: gray (<2500), white (2500-7499), green (>=7500).
 pub(crate) fn skill_prof_color(value: f32) -> egui::Color32 {
-    if value >= 75.0 {
+    if value >= 7500.0 {
         egui::Color32::from_rgb(100, 220, 100)
-    } else if value >= 25.0 {
+    } else if value >= 2500.0 {
         egui::Color32::WHITE
     } else {
         egui::Color32::GRAY

--- a/rust/src/ui/roster_panel.rs
+++ b/rust/src/ui/roster_panel.rs
@@ -236,14 +236,10 @@ pub fn roster_panel_system(
                     }
 
                     if row.top_skill > 0.0 {
-                        let prof_color = if row.top_skill >= 75.0 {
-                            egui::Color32::from_rgb(100, 220, 100)
-                        } else if row.top_skill >= 25.0 {
-                            egui::Color32::WHITE
-                        } else {
-                            egui::Color32::GRAY
-                        };
-                        ui.colored_label(prof_color, format!("{}", row.top_skill as i32));
+                        ui.colored_label(
+                            super::skill_prof_color(row.top_skill),
+                            format!("{}", row.top_skill as i32),
+                        );
                     }
 
                     // Select button

--- a/rust/src/ui/roster_panel.rs
+++ b/rust/src/ui/roster_panel.rs
@@ -87,7 +87,13 @@ pub fn roster_panel_system(
                 trait_name: personality_q.get(npc.entity).map(|p| p.trait_summary()).unwrap_or_default(),
                 top_skill: skills_q
                     .get(npc.entity)
-                    .map(|s| s.farming.max(s.combat).max(s.dodge))
+                    .map(|s| match npc.job {
+                        Job::Farmer => s.farming,
+                        Job::Archer | Job::Crossbow | Job::Fighter | Job::Raider => {
+                            s.combat.max(s.dodge)
+                        }
+                        _ => 0.0,
+                    })
                     .unwrap_or(0.0),
             });
         }

--- a/rust/src/ui/roster_panel.rs
+++ b/rust/src/ui/roster_panel.rs
@@ -7,7 +7,7 @@ use crate::components::*;
 use crate::resources::*;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
-enum SortColumn { Name, Job, Level, Hp, State, Trait }
+enum SortColumn { Name, Job, Level, Hp, State, Trait, Prof }
 
 #[derive(Default)]
 pub struct RosterState {
@@ -29,6 +29,7 @@ struct RosterRow {
     max_hp: f32,
     state: String,
     trait_name: String,
+    top_skill: f32,
 }
 
 pub fn roster_panel_system(
@@ -45,6 +46,7 @@ pub fn roster_panel_system(
     health_q: Query<&Health, Without<Building>>,
     cached_stats_q: Query<&CachedStats>,
     combat_state_q: Query<&CombatState>,
+    skills_q: Query<&NpcSkills>,
 ) -> Result {
     if !ui_state.roster_open {
         return Ok(());
@@ -83,6 +85,10 @@ pub fn roster_panel_system(
                 max_hp: cached_stats_q.get(npc.entity).map(|s| s.max_health).unwrap_or(100.0),
                 state: state_str,
                 trait_name: personality_q.get(npc.entity).map(|p| p.trait_summary()).unwrap_or_default(),
+                top_skill: skills_q
+                    .get(npc.entity)
+                    .map(|s| s.farming.max(s.combat).max(s.dodge))
+                    .unwrap_or(0.0),
             });
         }
 
@@ -96,6 +102,7 @@ pub fn roster_panel_system(
                     SortColumn::Hp => a.hp.partial_cmp(&b.hp).unwrap_or(std::cmp::Ordering::Equal),
                     SortColumn::State => a.state.cmp(&b.state),
                     SortColumn::Trait => a.trait_name.cmp(&b.trait_name),
+                    SortColumn::Prof => a.top_skill.partial_cmp(&b.top_skill).unwrap_or(std::cmp::Ordering::Equal),
                 };
                 if state.sort_descending { ord.reverse() } else { ord }
             });
@@ -152,6 +159,7 @@ pub fn roster_panel_system(
         let hp_arrow = arrow_str(&state, SortColumn::Hp);
         let state_arrow = arrow_str(&state, SortColumn::State);
         let trait_arrow = arrow_str(&state, SortColumn::Trait);
+        let prof_arrow = arrow_str(&state, SortColumn::Prof);
 
         // Header row
         let mut clicked_col: Option<SortColumn> = None;
@@ -162,6 +170,7 @@ pub fn roster_panel_system(
             if ui.button(format!("HP{}", hp_arrow)).clicked() { clicked_col = Some(SortColumn::Hp); }
             if ui.button(format!("State{}", state_arrow)).clicked() { clicked_col = Some(SortColumn::State); }
             if ui.button(format!("Trait{}", trait_arrow)).clicked() { clicked_col = Some(SortColumn::Trait); }
+            if ui.button(format!("Prof{}", prof_arrow)).clicked() { clicked_col = Some(SortColumn::Prof); }
         });
 
         if let Some(col) = clicked_col {
@@ -224,6 +233,17 @@ pub fn roster_panel_system(
 
                     if !row.trait_name.is_empty() {
                         ui.small(&row.trait_name);
+                    }
+
+                    if row.top_skill > 0.0 {
+                        let prof_color = if row.top_skill >= 75.0 {
+                            egui::Color32::from_rgb(100, 220, 100)
+                        } else if row.top_skill >= 25.0 {
+                            egui::Color32::WHITE
+                        } else {
+                            egui::Color32::GRAY
+                        };
+                        ui.colored_label(prof_color, format!("{}", row.top_skill as i32));
                     }
 
                     // Select button


### PR DESCRIPTION
## Summary

Skills UI for the inspector and roster panel. Rebased onto unclamped proficiency scaling (MAX=9999).

## Changes

- `ui/game_hud.rs`: Skills tab with progress bars (0-9999), color-coded proficiency, effect descriptions showing current multiplier. Dodge displays miss chance via `1 - 1/proficiency_mult()`. Filtered by job (farmers see farming, combat units see combat/dodge).
- `ui/roster_panel.rs`: Prof column with top skill value per NPC (job-relevant max), sortable.
- `ui/mod.rs`: `skill_prof_color()` thresholds updated for 0-9999 range (gray <2500, white 2500-7499, green >=7500).
- `world.rs`: Tower pathing uses registry-driven `def.is_tower` loop.

## Compliance

- **k8s.md**: UI reads NpcSkills component directly. No Def caching.
- **authority.md**: CPU-only UI queries. No GPU readback.
- **performance.md**: Roster cadenced (30-frame cache). Inspector single-entity O(1).

Closes #114