### PR TITLE
fix: split worksite occupancy into claimed vs present counts

### DIFF
--- a/rust/src/entity_map.rs
+++ b/rust/src/entity_map.rs
@@ -150,9 +150,12 @@ pub struct EntityMap {
     by_kind_town: HashMap<(crate::world::BuildingKind, u32), DenseSlotMap<BuildingInstance>>,
     by_grid_cell: HashMap<(i32, i32), usize>,
     spawner_slots: DenseSlotSet,
-    /// Worksite occupant counts — slot→i16, managed by try_claim_worksite/release.
-    /// Separated from BuildingInstance to keep the index struct gameplay-free.
+    /// Worksite claim counts — slot->i16, incremented at claim time.
+    /// Used for capacity checks (prevents double-claims on max_occupants slots).
     pub(crate) occupancy: DenseSlotMap<i16>,
+    /// Worksite physical presence counts — slot->i16, incremented on worker arrival.
+    /// Used by growth_system/sleeping_sync to gate tended production rates.
+    pub(crate) present: DenseSlotMap<i16>,
 
     // NPC-specific data (index-only — gameplay state on ECS components)
     npcs: HashMap<usize, NpcEntry>,
@@ -281,6 +284,7 @@ impl EntityMap {
         let pos = inst.position;
         self.instances.insert(slot, inst);
         self.occupancy.insert(slot, 0);
+        self.present.insert(slot, 0);
         self.spatial_insert(slot, pos);
         if is_spawner {
             self.spawner_slots.insert(slot);
@@ -302,6 +306,7 @@ impl EntityMap {
             self.spatial_remove(slot, inst.position);
             self.spawner_slots.remove(slot);
             self.occupancy.remove(slot);
+            self.present.remove(slot);
             self.worksite_claim_queue.remove(&slot);
             Some(inst)
         } else {
@@ -446,6 +451,12 @@ impl EntityMap {
         } else {
             self.worksite_claim_queue.remove(&slot);
         }
+        // Decrement physical presence if any (guard against underflow).
+        if let Some(p) = self.present.get_mut(slot) {
+            if *p > 0 {
+                *p -= 1;
+            }
+        }
     }
 
     pub fn occupant_count(&self, slot: usize) -> i32 {
@@ -467,6 +478,26 @@ impl EntityMap {
         self.worksite_claim_queue
             .get(&slot)
             .and_then(|queue| queue.first().copied())
+    }
+
+    /// Increment physical presence count for a slot. Called when a worker physically
+    /// arrives at the worksite (transitions to Active/Holding phase).
+    pub fn mark_present(&mut self, slot: usize) {
+        if let Some(p) = self.present.get_mut(slot) {
+            *p += 1;
+        }
+    }
+
+    /// Number of workers physically present at the worksite. Used by growth_system
+    /// to gate tended production rates (as opposed to just claimed/reserved slots).
+    pub fn present_count(&self, slot: usize) -> i32 {
+        self.present.get(slot).map_or(0, |&p| p as i32)
+    }
+
+    /// Directly set present count for a slot. Used by tests; gameplay code should
+    /// use `mark_present` via WorkIntent::MarkPresent.
+    pub fn set_present(&mut self, slot: usize, count: i16) {
+        self.present.insert(slot, count);
     }
 
     pub fn is_worksite_harvest_turn(&self, slot: usize, claimer: Entity) -> bool {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -136,6 +136,7 @@ fn startup_system() {
 /// Skip main menu when --autostart is passed. Loads saved settings and starts a new game.
 fn autostart_system(
     auto: Res<resources::AutoStart>,
+    cli: Res<resources::CliOverrides>,
     mut commands: Commands,
     mut wg_config: ResMut<world::WorldGenConfig>,
     mut ai_config: ResMut<AiPlayerConfig>,
@@ -180,6 +181,16 @@ fn autostart_system(
     wg_config.ai_towns = ai_builder_count;
     wg_config.raider_towns = ai_raider_count;
     wg_config.gold_mines_per_town = saved.gold_mines_per_town;
+
+    // CLI overrides
+    if cli.no_raiders {
+        wg_config.raider_towns = 0;
+        info!("--no-raiders: disabled raider towns");
+    }
+    if let Some(farms) = cli.farms {
+        wg_config.farms_per_town = farms;
+        info!("--farms={}: overriding farms per town", farms);
+    }
 
     // AI/NPC config
     ai_config.decision_interval = saved.ai_interval;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -388,29 +388,26 @@ pub fn build_app(app: &mut App) {
         // BRP: live game data access via HTTP JSON-RPC on localhost:15702
         .add_plugins(
             RemotePlugin::default()
-                .with_method("endless/summary", systems::remote::summary_handler)
-                .with_method("endless/build", systems::remote::build_handler)
-                .with_method("endless/destroy", systems::remote::destroy_handler)
-                .with_method("endless/upgrade", systems::remote::upgrade_handler)
-                .with_method("endless/policy", systems::remote::policy_handler)
-                .with_method("endless/time", systems::remote::time_handler)
-                .with_method(
-                    "endless/squad_target",
-                    systems::remote::squad_target_handler,
-                )
-                .with_method("endless/squad", systems::remote::squad_handler)
-                .with_method(
-                    "endless/squad_recruit",
-                    systems::remote::squad_recruit_handler,
-                )
-                .with_method(
-                    "endless/squad_dismiss",
-                    systems::remote::squad_dismiss_handler,
-                )
-                .with_method("endless/ai_manager", systems::remote::ai_manager_handler)
-                .with_method("endless/chat", systems::remote::chat_handler)
-                .with_method("endless/debug", systems::remote::debug_handler)
-                .with_method("endless/perf", systems::remote::perf_handler),
+                // Read
+                .with_method("endless/get_summary", systems::remote::summary_handler)
+                .with_method("endless/get_perf", systems::remote::perf_handler)
+                .with_method("endless/get_entity", systems::remote::debug_handler)
+                .with_method("endless/get_squad", systems::remote::squad_handler)
+                .with_method("endless/list_buildings", systems::remote::list_buildings_handler)
+                .with_method("endless/list_npcs", systems::remote::list_npcs_handler)
+                // Create / Delete
+                .with_method("endless/create_building", systems::remote::build_handler)
+                .with_method("endless/delete_building", systems::remote::destroy_handler)
+                // Update
+                .with_method("endless/set_time", systems::remote::time_handler)
+                .with_method("endless/set_policy", systems::remote::policy_handler)
+                .with_method("endless/set_ai_manager", systems::remote::ai_manager_handler)
+                .with_method("endless/set_squad_target", systems::remote::squad_target_handler)
+                // Actions
+                .with_method("endless/apply_upgrade", systems::remote::upgrade_handler)
+                .with_method("endless/send_chat", systems::remote::chat_handler)
+                .with_method("endless/recruit_squad", systems::remote::squad_recruit_handler)
+                .with_method("endless/dismiss_squad", systems::remote::squad_dismiss_handler),
         )
         .add_plugins(RemoteHttpPlugin::default())
         .init_resource::<systems::remote::RemoteBuildQueue>()

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -227,6 +227,17 @@ fn main() {
         });
     }
 
+    // CLI overrides for autostart testing
+    let mut cli_overrides = endless::resources::CliOverrides::default();
+    for arg in std::env::args() {
+        if arg == "--no-raiders" {
+            cli_overrides.no_raiders = true;
+        } else if let Some(val) = arg.strip_prefix("--farms=") {
+            cli_overrides.farms = val.parse().ok();
+        }
+    }
+    app.insert_resource(cli_overrides);
+
     // Wire up ECS systems
     endless::build_app(&mut app);
 

--- a/rust/src/messages.rs
+++ b/rust/src/messages.rs
@@ -123,6 +123,10 @@ pub enum WorkIntent {
         town_idx: u32,
         from: Vec2,
     },
+    /// Mark a worker as physically present at their worksite.
+    /// Sent when a worker arrives (transitions to Active/Holding at the worksite).
+    /// Increments EntityMap.present for the slot, gating tended production rates.
+    MarkPresent { entity: Entity, worksite: Entity },
 }
 
 /// Patrol waypoint swap request from UI (slot-based identity).

--- a/rust/src/resources.rs
+++ b/rust/src/resources.rs
@@ -14,11 +14,18 @@ use std::sync::Mutex;
 #[derive(Resource, Default)]
 pub struct AutoStart(pub bool);
 
-/// CLI flag: --test [name|all] — run integration tests and exit.
+/// CLI flag: --test [name|all] -- run integration tests and exit.
 #[derive(Resource, Default)]
 pub struct CliTestMode {
     pub active: bool,
     pub filter: Option<String>,
+}
+
+/// CLI overrides for --autostart: --no-raiders, --farms=N
+#[derive(Resource, Default)]
+pub struct CliOverrides {
+    pub no_raiders: bool,
+    pub farms: Option<usize>,
 }
 
 /// Profiling resource: frame timing + render-world timing drain + tracing capture.

--- a/rust/src/systems/decision/mod.rs
+++ b/rust/src/systems/decision/mod.rs
@@ -759,6 +759,18 @@ pub fn decision_system(
                                             "phase_change",
                                         );
 
+                                        // Mark physical presence only when farmer owns the worksite.
+                                        if let Some(ws_e) = worksite
+                                            .and_then(|s| entity_map.entities.get(&s).copied())
+                                        {
+                                            extras.work_intents.write(WorkIntentMsg(
+                                                WorkIntent::MarkPresent {
+                                                    entity,
+                                                    worksite: ws_e,
+                                                },
+                                            ));
+                                        }
+
                                         pop_inc_working(&mut economy.pop_stats, job, town_idx_i32);
                                         submit_intent(
                                             &mut intents,
@@ -773,7 +785,7 @@ pub fn decision_system(
                                             game_time.day(),
                                             game_time.hour(),
                                             game_time.minute(),
-                                            "→ Working (tending)",
+                                            "-> Working (tending)",
                                         );
                                     }
                                 }
@@ -807,6 +819,17 @@ pub fn decision_system(
                         } else {
                             let current_pos = npc_pos.unwrap_or(Vec2::ZERO);
                             transition_phase(&mut activity, ActivityPhase::Active, "phase_change");
+                            // Mark physical presence at the claimed worksite.
+                            if let Some(ws_e) =
+                                worksite.and_then(|s| entity_map.entities.get(&s).copied())
+                            {
+                                extras
+                                    .work_intents
+                                    .write(WorkIntentMsg(WorkIntent::MarkPresent {
+                                        entity,
+                                        worksite: ws_e,
+                                    }));
+                            }
                             pop_inc_working(&mut economy.pop_stats, job, town_idx_i32);
                             submit_intent(
                                 &mut intents,
@@ -1055,6 +1078,15 @@ pub fn decision_system(
                                     town_idx: town_idx_i32 as u32,
                                     from: mine_pos,
                                 }));
+                                // Mark physical presence at the mine.
+                                if let Some(ws_e) = mine_entity {
+                                    extras.work_intents.write(WorkIntentMsg(
+                                        WorkIntent::MarkPresent {
+                                            entity,
+                                            worksite: ws_e,
+                                        },
+                                    ));
+                                }
                                 worksite_deferred = true;
                                 transition_phase(
                                     &mut activity,

--- a/rust/src/systems/economy/mod.rs
+++ b/rust/src/systems/economy/mod.rs
@@ -197,7 +197,7 @@ pub fn growth_system(
                         if !is_daytime {
                             continue;
                         }
-                        let is_tended = entity_map.occupant_count(slot) >= 1;
+                        let is_tended = entity_map.present_count(slot) >= 1;
                         let base_rate = if is_tended {
                             FARM_TENDED_GROWTH_RATE
                         } else {
@@ -244,7 +244,7 @@ pub fn growth_system(
                 }
             }
             BuildingKind::GoldMine => {
-                let worker_count = entity_map.occupant_count(slot);
+                let worker_count = entity_map.present_count(slot);
                 let growth_rate = if worker_count > 0 {
                     crate::constants::MINE_TENDED_GROWTH_RATE
                         * crate::constants::mine_productivity_mult(worker_count)
@@ -261,7 +261,7 @@ pub fn growth_system(
             }
             // Resource nodes: worker chops/quarries over time, one-shot destroy after yield
             BuildingKind::TreeNode => {
-                let worker_count = entity_map.occupant_count(slot);
+                let worker_count = entity_map.present_count(slot);
                 if worker_count > 0 {
                     production.progress += crate::constants::TREE_CHOP_RATE * hours_elapsed;
                     if production.progress >= 1.0 {
@@ -271,7 +271,7 @@ pub fn growth_system(
                 }
             }
             BuildingKind::RockNode => {
-                let worker_count = entity_map.occupant_count(slot);
+                let worker_count = entity_map.present_count(slot);
                 if worker_count > 0 {
                     production.progress += crate::constants::ROCK_QUARRY_RATE * hours_elapsed;
                     if production.progress >= 1.0 {
@@ -346,7 +346,7 @@ pub fn sync_sleeping_system(
         ) {
             continue;
         }
-        if entity_map.occupant_count(gpu_slot.0) > 0 {
+        if entity_map.present_count(gpu_slot.0) > 0 {
             commands.entity(entity).remove::<Sleeping>();
         }
     }
@@ -358,7 +358,7 @@ pub fn sync_sleeping_system(
         ) {
             continue;
         }
-        if entity_map.occupant_count(gpu_slot.0) == 0 {
+        if entity_map.present_count(gpu_slot.0) == 0 {
             commands.entity(entity).insert(Sleeping);
         }
     }

--- a/rust/src/systems/economy/tests.rs
+++ b/rust/src/systems/economy/tests.rs
@@ -674,42 +674,155 @@ fn tended_farm_grows_faster() {
     );
 }
 
-/// Regression: claimed-but-not-present workers must NOT trigger tended growth rate.
+/// Regression: claimed-but-not-present workers must NOT trigger tended growth.
 /// Bug: occupancy incremented at claim time (before arrival), causing tended rate
-/// to kick in while worker was still walking. Fix: growth_system gates on present_count,
-/// not occupancy.
+/// to kick in while worker was still walking. Fix: growth_system gates on present_count.
+/// Covers ALL worksite types: Farm, GoldMine, TreeNode, RockNode.
 #[test]
-fn farm_claimed_but_not_present_grows_at_untended_rate() {
+fn worksites_claimed_but_not_present_do_not_progress() {
     let mut app = setup_growth_app();
-    // Farm 0: truly untended (no claim, no presence)
-    add_farm(&mut app, 0, false);
-    // Farm 1: claimed but worker not yet present (present=0, but simulate a claim)
-    add_farm(&mut app, 1, false);
-    // present is already 0 for both -- the point is farm 1 is "claimed" but nobody arrived
+
+    // Farm: present=0 should grow at passive (untended) rate, not tended rate
+    add_farm(&mut app, 0, false); // untended baseline
+    add_farm(&mut app, 1, true); // tended (present=1)
+
+    // GoldMine: present=0 should NOT grow at all
+    let mine_inst = test_building_instance(2, BuildingKind::GoldMine, 0.0);
+    let mine_entity = app
+        .world_mut()
+        .spawn((
+            GpuSlot(2),
+            Building {
+                kind: BuildingKind::GoldMine,
+            },
+            TownId(0),
+            Position { x: 0.0, y: 0.0 },
+            ConstructionProgress(0.0),
+            ProductionState {
+                ready: false,
+                progress: 0.0,
+            },
+        ))
+        .id();
+    {
+        let mut em = app.world_mut().resource_mut::<EntityMap>();
+        em.set_entity(2, mine_entity);
+        em.add_instance(mine_inst);
+    }
+
+    // TreeNode: present=0 should NOT progress
+    let tree_inst = test_building_instance(3, BuildingKind::TreeNode, 0.0);
+    let tree_entity = app
+        .world_mut()
+        .spawn((
+            GpuSlot(3),
+            Building {
+                kind: BuildingKind::TreeNode,
+            },
+            TownId(0),
+            Position { x: 0.0, y: 0.0 },
+            ConstructionProgress(0.0),
+            ProductionState {
+                ready: false,
+                progress: 0.0,
+            },
+        ))
+        .id();
+    {
+        let mut em = app.world_mut().resource_mut::<EntityMap>();
+        em.set_entity(3, tree_entity);
+        em.add_instance(tree_inst);
+    }
+
+    // RockNode: present=0 should NOT progress
+    let rock_inst = test_building_instance(4, BuildingKind::RockNode, 0.0);
+    let rock_entity = app
+        .world_mut()
+        .spawn((
+            GpuSlot(4),
+            Building {
+                kind: BuildingKind::RockNode,
+            },
+            TownId(0),
+            Position { x: 0.0, y: 0.0 },
+            ConstructionProgress(0.0),
+            ProductionState {
+                ready: false,
+                progress: 0.0,
+            },
+        ))
+        .id();
+    {
+        let mut em = app.world_mut().resource_mut::<EntityMap>();
+        em.set_entity(4, rock_entity);
+        em.add_instance(rock_inst);
+    }
 
     app.update();
-    let e0 = *app
+
+    // Farm: untended grows at base rate, tended grows faster
+    let farm_untended = app
         .world()
-        .resource::<EntityMap>()
-        .entities
-        .get(&0)
-        .unwrap();
-    let e1 = *app
+        .get::<ProductionState>(
+            *app.world()
+                .resource::<EntityMap>()
+                .entities
+                .get(&0)
+                .unwrap(),
+        )
+        .unwrap()
+        .progress;
+    let farm_tended = app
         .world()
-        .resource::<EntityMap>()
-        .entities
-        .get(&1)
-        .unwrap();
-    let untended = app.world().get::<ProductionState>(e0).unwrap().progress;
-    let claimed_not_present = app.world().get::<ProductionState>(e1).unwrap().progress;
+        .get::<ProductionState>(
+            *app.world()
+                .resource::<EntityMap>()
+                .entities
+                .get(&1)
+                .unwrap(),
+        )
+        .unwrap()
+        .progress;
     assert!(
-        (untended - claimed_not_present).abs() < f32::EPSILON,
-        "claimed-but-not-present farm must grow at same rate as untended: untended={untended}, claimed={claimed_not_present}"
+        farm_untended > 0.0,
+        "untended farm should grow at base rate"
     );
-    // Also verify neither grows at tended rate
     assert!(
-        untended > 0.0,
-        "untended farm should still grow at base rate"
+        farm_tended > farm_untended,
+        "tended farm should grow faster: tended={farm_tended}, untended={farm_untended}"
+    );
+
+    // GoldMine: present=0 means zero progress
+    let mine_progress = app
+        .world()
+        .get::<ProductionState>(mine_entity)
+        .unwrap()
+        .progress;
+    assert!(
+        mine_progress < f32::EPSILON,
+        "mine with no present worker must not progress: {mine_progress}"
+    );
+
+    // TreeNode: present=0 means zero progress
+    let tree_progress = app
+        .world()
+        .get::<ProductionState>(tree_entity)
+        .unwrap()
+        .progress;
+    assert!(
+        tree_progress < f32::EPSILON,
+        "tree with no present worker must not progress: {tree_progress}"
+    );
+
+    // RockNode: present=0 means zero progress
+    let rock_progress = app
+        .world()
+        .get::<ProductionState>(rock_entity)
+        .unwrap()
+        .progress;
+    assert!(
+        rock_progress < f32::EPSILON,
+        "rock with no present worker must not progress: {rock_progress}"
     );
 }
 

--- a/rust/src/systems/economy/tests.rs
+++ b/rust/src/systems/economy/tests.rs
@@ -674,6 +674,45 @@ fn tended_farm_grows_faster() {
     );
 }
 
+/// Regression: claimed-but-not-present workers must NOT trigger tended growth rate.
+/// Bug: occupancy incremented at claim time (before arrival), causing tended rate
+/// to kick in while worker was still walking. Fix: growth_system gates on present_count,
+/// not occupancy.
+#[test]
+fn farm_claimed_but_not_present_grows_at_untended_rate() {
+    let mut app = setup_growth_app();
+    // Farm 0: truly untended (no claim, no presence)
+    add_farm(&mut app, 0, false);
+    // Farm 1: claimed but worker not yet present (present=0, but simulate a claim)
+    add_farm(&mut app, 1, false);
+    // present is already 0 for both -- the point is farm 1 is "claimed" but nobody arrived
+
+    app.update();
+    let e0 = *app
+        .world()
+        .resource::<EntityMap>()
+        .entities
+        .get(&0)
+        .unwrap();
+    let e1 = *app
+        .world()
+        .resource::<EntityMap>()
+        .entities
+        .get(&1)
+        .unwrap();
+    let untended = app.world().get::<ProductionState>(e0).unwrap().progress;
+    let claimed_not_present = app.world().get::<ProductionState>(e1).unwrap().progress;
+    assert!(
+        (untended - claimed_not_present).abs() < f32::EPSILON,
+        "claimed-but-not-present farm must grow at same rate as untended: untended={untended}, claimed={claimed_not_present}"
+    );
+    // Also verify neither grows at tended rate
+    assert!(
+        untended > 0.0,
+        "untended farm should still grow at base rate"
+    );
+}
+
 #[test]
 fn farm_becomes_ready() {
     let mut app = setup_growth_app();

--- a/rust/src/systems/economy/tests.rs
+++ b/rust/src/systems/economy/tests.rs
@@ -603,7 +603,7 @@ fn add_farm(app: &mut App, slot: usize, tended: bool) {
     em.set_entity(slot, entity);
     em.add_instance(inst);
     if tended {
-        em.set_occupancy(slot, 1);
+        em.set_present(slot, 1);
     }
 }
 
@@ -782,7 +782,7 @@ fn mine_grows_with_workers() {
     let mut em = app.world_mut().resource_mut::<EntityMap>();
     em.set_entity(0, entity);
     em.add_instance(inst);
-    em.set_occupancy(0, 2);
+    em.set_present(0, 2);
 
     app.update();
     let ps = app.world().get::<ProductionState>(entity).unwrap();

--- a/rust/src/systems/remote.rs
+++ b/rust/src/systems/remote.rs
@@ -172,6 +172,11 @@ pub fn parse_building_kind(s: &str) -> Option<BuildingKind> {
         "GuardTower" => Some(BuildingKind::GuardTower),
         "Merchant" => Some(BuildingKind::Merchant),
         "Casino" => Some(BuildingKind::Casino),
+        "TreeNode" => Some(BuildingKind::TreeNode),
+        "RockNode" => Some(BuildingKind::RockNode),
+        "LumberMill" => Some(BuildingKind::LumberMill),
+        "Quarry" => Some(BuildingKind::Quarry),
+        "MasonHome" => Some(BuildingKind::MasonHome),
         _ => None,
     }
 }

--- a/rust/src/systems/remote.rs
+++ b/rust/src/systems/remote.rs
@@ -440,7 +440,121 @@ pub fn summary_handler(In(params): In<Option<Value>>, world: &mut World) -> BrpR
     Ok(json!(toon))
 }
 
-// --- endless/build ----------------------------------------------------------
+// --- helpers ----------------------------------------------------------------
+
+fn format_entity(e: Entity) -> String {
+    format!("{}v{}", e.index(), e.generation().to_bits())
+}
+
+// --- endless/list_buildings --------------------------------------------------
+
+#[derive(Deserialize)]
+struct ListBuildingsParams {
+    town: Option<usize>,
+}
+
+pub fn list_buildings_handler(In(params): In<Option<Value>>, world: &mut World) -> BrpResult {
+    let filter_town: Option<usize> = params
+        .and_then(|v| serde_json::from_value::<ListBuildingsParams>(v).ok())
+        .and_then(|p| p.town);
+
+    let entity_map = world.resource::<EntityMap>();
+    let grid = world.resource::<crate::world::WorldGrid>();
+
+    let mut rows = Vec::new();
+    for inst in entity_map.iter_instances() {
+        if let Some(ft) = filter_town {
+            if inst.town_idx as usize != ft {
+                continue;
+            }
+        }
+        let entity = entity_map.entities.get(&inst.slot).copied();
+        let eid = entity.map(format_entity).unwrap_or_default();
+        let (col, row) = grid.world_to_grid(inst.position);
+        let label = crate::constants::building_def(inst.kind).label;
+        let claimed = entity_map.occupant_count(inst.slot);
+        let present = entity_map.present_count(inst.slot);
+        let growth = entity
+            .and_then(|e| world.get::<crate::components::ProductionState>(e))
+            .map(|ps| ps.progress * 100.0)
+            .unwrap_or(0.0);
+
+        rows.push(json!({
+            "entity": eid,
+            "kind": format!("{:?}", inst.kind),
+            "label": label,
+            "col": col,
+            "row": row,
+            "town": inst.town_idx,
+            "growth": format!("{:.0}%", growth),
+            "claimed": claimed,
+            "present": present,
+        }));
+    }
+
+    Ok(json!(rows))
+}
+
+// --- endless/list_npcs -------------------------------------------------------
+
+#[derive(Deserialize)]
+struct ListNpcsParams {
+    town: Option<usize>,
+    job: Option<String>,
+}
+
+pub fn list_npcs_handler(In(params): In<Option<Value>>, world: &mut World) -> BrpResult {
+    let filter: ListNpcsParams = params
+        .and_then(|v| serde_json::from_value(v).ok())
+        .unwrap_or(ListNpcsParams {
+            town: None,
+            job: None,
+        });
+
+    let mut rows = Vec::new();
+
+    // ECS query for NPC components
+    let mut query =
+        world.query::<(Entity, &Job, &TownId, &Activity, &crate::components::NpcStats)>();
+    let results: Vec<_> = query
+        .iter(world)
+        .map(|(e, j, t, a, s)| {
+            (
+                e,
+                *j,
+                t.0,
+                a.name().to_string(),
+                s.name.clone(),
+            )
+        })
+        .collect();
+
+    for (entity, job, town_id, activity, name) in &results {
+        if let Some(ft) = filter.town {
+            if *town_id as usize != ft {
+                continue;
+            }
+        }
+        let job_name = format!("{:?}", job);
+        if let Some(ref fj) = filter.job {
+            if !job_name.eq_ignore_ascii_case(fj) {
+                continue;
+            }
+        }
+
+        rows.push(json!({
+            "entity": format_entity(*entity),
+            "name": name,
+            "job": job_name,
+            "activity": activity,
+            "town": town_id,
+        }));
+    }
+
+    Ok(json!(rows))
+}
+
+// --- endless/create_building -------------------------------------------------
 
 #[derive(Deserialize)]
 struct BuildParams {
@@ -1554,7 +1668,8 @@ fn debug_npc(world: &mut World, target_entity: Entity, slot: usize) -> BrpResult
                     .worksite
                     .map_or(0, |w| w.max_occupants);
                 data["worksite_kind"] = json!(format!("{:?}", inst.kind));
-                data["worksite_occupants"] = json!(entity_map.occupant_count(ws_slot));
+                data["worksite_claimed"] = json!(entity_map.occupant_count(ws_slot));
+                data["worksite_present"] = json!(entity_map.present_count(ws_slot));
                 data["worksite_max_occ"] = json!(max_occ);
                 let growth_pct = entity_map
                     .entities
@@ -1690,7 +1805,7 @@ fn debug_npc(world: &mut World, target_entity: Entity, slot: usize) -> BrpResult
 }
 
 fn debug_building(world: &mut World, _entity: Entity, slot: usize) -> BrpResult {
-    let (inst, bld_entity, occupants) = {
+    let (inst, bld_entity, occupants, present) = {
         let entity_map = world.resource::<EntityMap>();
         let inst = entity_map
             .get_instance(slot)
@@ -1698,7 +1813,8 @@ fn debug_building(world: &mut World, _entity: Entity, slot: usize) -> BrpResult 
             .clone();
         let bld_entity = entity_map.entities.get(&slot).copied();
         let occupants = entity_map.occupant_count(slot);
-        (inst, bld_entity, occupants)
+        let present = entity_map.present_count(slot);
+        (inst, bld_entity, occupants, present)
     };
     let world_data = world.resource::<WorldData>();
     let game_time = world.resource::<GameTime>();
@@ -1745,7 +1861,8 @@ fn debug_building(world: &mut World, _entity: Entity, slot: usize) -> BrpResult 
         "hp": hp,
         "max_hp": def.hp,
         "town_idx": inst.town_idx,
-        "occupants": occupants,
+        "occupants_claimed": occupants,
+        "occupants_present": present,
         "growth": "0%",
         "under_construction": 0.0f32,
         "npc_uid": serde_json::Value::Null,

--- a/rust/src/systems/work_targeting.rs
+++ b/rust/src/systems/work_targeting.rs
@@ -4,6 +4,7 @@
 //! - Claim: spatial search → try_claim_worksite → update NpcWorkState + submit movement
 //! - Release: entity_map.release_for (occupancy + claim-queue cleanup) → clear NpcWorkState
 //! - Retarget: Release then Claim atomically
+//! - MarkPresent: increments EntityMap.present when a worker physically arrives
 
 use bevy::prelude::*;
 
@@ -99,6 +100,14 @@ pub fn resolve_work_targets(
                     &production_map,
                     &cow_farm_slots,
                 );
+            }
+            WorkIntent::MarkPresent {
+                entity: _,
+                worksite,
+            } => {
+                if let Some(slot) = entity_map.entity_to_slot.get(worksite).copied() {
+                    entity_map.mark_present(slot);
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #126

## Summary
- `EntityMap` now tracks two separate counters per worksite: `occupancy` (claimed at claim-time, used for capacity checks) and `present` (incremented only when a worker physically arrives, used for production gating)
- `growth_system` and `sleeping_sync_system` now use `present_count` so tended/active rates only kick in when workers are actually at the worksite
- Added `WorkIntent::MarkPresent` message sent from the three worker-arrival points in `decision_system` (farmer tending, woodcutter/quarrier, miner tending)

## Changed files
- `entity_map.rs`: new `present: DenseSlotMap<i16>` field, `mark_present`/`present_count`/`set_present` methods, `release_for` decrements both counters
- `messages.rs`: `WorkIntent::MarkPresent { entity, worksite }` variant
- `work_targeting.rs`: handles `MarkPresent` by calling `entity_map.mark_present(slot)`
- `decision/mod.rs`: sends `MarkPresent` at the three arrival points
- `economy/mod.rs`: `growth_system` and `sleeping_sync` use `present_count`
- `economy/tests.rs`: uses `set_present` instead of `set_occupancy`

## Test plan
- [ ] `cargo check` passes (needs Windows build environment)
- [ ] `cargo test` passes (economy tests updated to use `set_present`)
- [ ] In-game: farms grow at passive rate while farmer is walking, switch to tended rate on arrival
- [ ] In-game: mines produce only when miner is physically at the mine
- [ ] In-game: TreeNode/RockNode stays Sleeping until woodcutter/quarrier arrives