### PR TITLE
fix: LOD boxes colored by resource type

### DIFF
--- a/rust/src/constants/buildings.rs
+++ b/rust/src/constants/buildings.rs
@@ -109,6 +109,8 @@ pub struct BuildingDef {
     pub autotile: bool,
     /// Which weapon type this tower accepts (None = no equipment slot).
     pub tower_weapon_type: Option<WeaponType>,
+    /// RGBA color used for the LOD box when zoomed out. White = no tint (default).
+    pub lod_color: [f32; 4],
 }
 
 impl BuildingDef {
@@ -152,6 +154,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: false,
         tower_weapon_type: None,
+        lod_color: [1.0, 1.0, 1.0, 1.0],
     },
     // 1: Bed
     BuildingDef {
@@ -175,6 +178,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: false,
         tower_weapon_type: None,
+        lod_color: [1.0, 1.0, 1.0, 1.0],
     },
     // 2: Waypoint
     BuildingDef {
@@ -198,6 +202,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: false,
         tower_weapon_type: None,
+        lod_color: [1.0, 1.0, 1.0, 1.0],
     },
     // 3: Farm
     BuildingDef {
@@ -228,6 +233,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         }),
         autotile: false,
         tower_weapon_type: None,
+        lod_color: [1.0, 0.85, 0.1, 1.0],
     },
     // 5: Farmer Home
     BuildingDef {
@@ -254,6 +260,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: false,
         tower_weapon_type: None,
+        lod_color: [1.0, 1.0, 1.0, 1.0],
     },
     // 6: Archer Home
     BuildingDef {
@@ -280,6 +287,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: false,
         tower_weapon_type: None,
+        lod_color: [1.0, 1.0, 1.0, 1.0],
     },
     // 7: Tent (raider spawner)
     BuildingDef {
@@ -306,6 +314,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: false,
         tower_weapon_type: None,
+        lod_color: [1.0, 1.0, 1.0, 1.0],
     },
     // 8: Gold Mine
     BuildingDef {
@@ -336,6 +345,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         }),
         autotile: false,
         tower_weapon_type: None,
+        lod_color: [1.0, 0.75, 0.0, 1.0],
     },
     // 9: Miner Home
     BuildingDef {
@@ -362,6 +372,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: false,
         tower_weapon_type: None,
+        lod_color: [1.0, 1.0, 1.0, 1.0],
     },
     // 10: Crossbow Home
     BuildingDef {
@@ -388,6 +399,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: false,
         tower_weapon_type: None,
+        lod_color: [1.0, 1.0, 1.0, 1.0],
     },
     // 11: Fighter Home
     BuildingDef {
@@ -414,6 +426,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: false,
         tower_weapon_type: None,
+        lod_color: [1.0, 1.0, 1.0, 1.0],
     },
     // 12: Road (dirt) — expands buildable area by 3 tiles
     BuildingDef {
@@ -437,6 +450,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: true,
         tower_weapon_type: None,
+        lod_color: [1.0, 1.0, 1.0, 1.0],
     },
     // 13: StoneRoad — expands buildable area by 5 tiles
     BuildingDef {
@@ -460,6 +474,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: true,
         tower_weapon_type: None,
+        lod_color: [1.0, 1.0, 1.0, 1.0],
     },
     // 14: MetalRoad — expands buildable area by 7 tiles
     BuildingDef {
@@ -483,6 +498,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: true,
         tower_weapon_type: None,
+        lod_color: [1.0, 1.0, 1.0, 1.0],
     },
     // 15: Wall
     BuildingDef {
@@ -506,6 +522,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: true,
         tower_weapon_type: None,
+        lod_color: [1.0, 1.0, 1.0, 1.0],
     },
     // 14: Bow Tower (auto-shoots enemies with arrows)
     BuildingDef {
@@ -529,6 +546,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: false,
         tower_weapon_type: Some(WeaponType::Bow),
+        lod_color: [1.0, 1.0, 1.0, 1.0],
     },
     // 15: Crossbow Tower
     BuildingDef {
@@ -552,6 +570,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: false,
         tower_weapon_type: Some(WeaponType::Crossbow),
+        lod_color: [1.0, 1.0, 1.0, 1.0],
     },
     // 16: Catapult Tower
     BuildingDef {
@@ -575,6 +594,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: false,
         tower_weapon_type: Some(WeaponType::Catapult),
+        lod_color: [1.0, 1.0, 1.0, 1.0],
     },
     // 15: Merchant (buy/sell equipment)
     BuildingDef {
@@ -598,6 +618,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: false,
         tower_weapon_type: None,
+        lod_color: [1.0, 1.0, 1.0, 1.0],
     },
     // 16: Casino (blackjack minigame, 1 per town)
     BuildingDef {
@@ -621,6 +642,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: false,
         tower_weapon_type: None,
+        lod_color: [1.0, 1.0, 1.0, 1.0],
     },
     // 17: LumberMill
     BuildingDef {
@@ -647,6 +669,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: false,
         tower_weapon_type: None,
+        lod_color: [1.0, 1.0, 1.0, 1.0],
     },
     // 18: Quarry
     BuildingDef {
@@ -673,6 +696,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: false,
         tower_weapon_type: None,
+        lod_color: [1.0, 1.0, 1.0, 1.0],
     },
     // 19: TreeNode
     BuildingDef {
@@ -703,6 +727,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         }),
         autotile: false,
         tower_weapon_type: None,
+        lod_color: [0.2, 0.8, 0.2, 1.0],
     },
     // 20: RockNode
     BuildingDef {
@@ -733,6 +758,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         }),
         autotile: false,
         tower_weapon_type: None,
+        lod_color: [0.55, 0.55, 0.6, 1.0],
     },
     // 21: Mason Home
     BuildingDef {
@@ -759,6 +785,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: false,
         tower_weapon_type: None,
+        lod_color: [1.0, 1.0, 1.0, 1.0],
     },
     // Gate (wall-like, passable for friendlies)
     BuildingDef {
@@ -782,6 +809,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: true,
         tower_weapon_type: None,
+        lod_color: [1.0, 1.0, 1.0, 1.0],
     },
     // Guard Tower (elevated tower, +range, requires wall adjacency)
     BuildingDef {
@@ -805,6 +833,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: false,
         tower_weapon_type: None,
+        lod_color: [1.0, 1.0, 1.0, 1.0],
     },
 ];
 

--- a/rust/src/npc_render.rs
+++ b/rust/src/npc_render.rs
@@ -727,7 +727,8 @@ fn build_building_body_instances(
         };
 
         let (r, g, b, a) = if faction == crate::constants::FACTION_PLAYER {
-            (1.0, 1.0, 1.0, 1.0)
+            let lc = crate::constants::building_def(inst.kind).lod_color;
+            (lc[0], lc[1], lc[2], lc[3])
         } else {
             // Buildings use a subtle faction tint (not full recolor like NPCs/projectiles).
             let (fr, fg, fb, _fa) = crate::constants::raider_faction_color(faction);

--- a/rust/src/npc_render.rs
+++ b/rust/src/npc_render.rs
@@ -726,7 +726,8 @@ fn build_building_body_instances(
             gpu_state.healths.get(idx).copied().unwrap_or(0.0)
         };
 
-        let (r, g, b, a) = if faction == crate::constants::FACTION_PLAYER {
+        let (r, g, b, a) = if faction <= crate::constants::FACTION_PLAYER {
+            // Neutral (resource nodes) and player buildings both use lod_color.
             let lc = crate::constants::building_def(inst.kind).lod_color;
             (lc[0], lc[1], lc[2], lc[3])
         } else {


### PR DESCRIPTION
Fixes #131.

## Changes

- Added `lod_color: [f32; 4]` field to `BuildingDef` (k8s Def pattern, white default = no tint)
- Set resource-type colors in `BUILDING_REGISTRY`:
  - `TreeNode`: green `[0.2, 0.8, 0.2, 1.0]` (wood)
  - `RockNode`: gray `[0.55, 0.55, 0.6, 1.0]` (stone)
  - `Farm`: yellow `[1.0, 0.85, 0.1, 1.0]` (food)
  - `GoldMine`: gold `[1.0, 0.75, 0.0, 1.0]` (gold)
- `build_building_body_instances` reads `building_def(inst.kind).lod_color` for player buildings instead of hardcoded white

The shader already uses `in.color.rgb` as the flat LOD box color when `zoom < lod_zoom`. All other buildings keep white (`[1.0, 1.0, 1.0, 1.0]`) = no change at either zoom level.

## Tests

- `cargo check` passes
- `cargo clippy --release -- -D warnings` passes