### PR TITLE
test: message signal regression tests for event-driven systems

### DIFF
--- a/rust/src/gpu.rs
+++ b/rust/src/gpu.rs
@@ -2584,4 +2584,91 @@ mod tests {
         assert_eq!(writes.active_set_index[7], 1);
         assert_eq!(writes.active_set_index[9], usize::MAX);
     }
+
+    // ── build_visual_upload signal tests ─────────────────────────────────
+
+    fn setup_visual_app() -> App {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.insert_resource(EntityGpuState {
+            visual_full_rebuild: false,
+            visual_dirty_indices: Vec::new(),
+            ..Default::default()
+        });
+        app.insert_resource(GpuSlotPool::default());
+        app.insert_resource(NpcVisualUpload::default());
+        app.insert_resource(crate::resources::EntityMap::default());
+        app.add_systems(Update, build_visual_upload);
+        app
+    }
+
+    #[test]
+    fn build_visual_upload_noop_without_dirty_indices() {
+        let mut app = setup_visual_app();
+        // No dirty indices and no full rebuild
+        app.update();
+        let upload = app.world().resource::<NpcVisualUpload>();
+        assert!(
+            upload.visual_uploaded_indices.is_empty(),
+            "no dirty indices means nothing uploaded"
+        );
+        assert!(
+            upload.equip_uploaded_indices.is_empty(),
+            "no dirty indices means no equip uploaded"
+        );
+    }
+
+    #[test]
+    fn build_visual_upload_only_processes_dirty_indices() {
+        let mut app = setup_visual_app();
+        // Mark slot 3 as dirty
+        app.world_mut()
+            .resource_mut::<EntityGpuState>()
+            .visual_dirty_indices
+            .push(3);
+        // Give the slot pool a non-zero count so visual_data is resized
+        {
+            let mut pool = app.world_mut().resource_mut::<GpuSlotPool>();
+            // Alloc slots 0..4 so count() >= 4
+            for _ in 0..4 {
+                pool.alloc_reset();
+            }
+        }
+        app.update();
+        let upload = app.world().resource::<NpcVisualUpload>();
+        assert_eq!(
+            upload.visual_uploaded_indices,
+            vec![3],
+            "only the dirty slot should be in visual_uploaded_indices"
+        );
+        // Slot 0, 1, 2 should NOT be in the upload list
+        assert!(
+            !upload.visual_uploaded_indices.contains(&0),
+            "slot 0 should not be uploaded"
+        );
+    }
+
+    #[test]
+    fn build_visual_upload_noop_on_second_frame_without_new_dirty() {
+        let mut app = setup_visual_app();
+        {
+            let mut pool = app.world_mut().resource_mut::<GpuSlotPool>();
+            for _ in 0..4 {
+                pool.alloc_reset();
+            }
+        }
+        // First frame: dirty slot 3
+        app.world_mut()
+            .resource_mut::<EntityGpuState>()
+            .visual_dirty_indices
+            .push(3);
+        app.update();
+        // Second frame: no new dirty indices
+        app.update();
+        let upload = app.world().resource::<NpcVisualUpload>();
+        assert!(
+            upload.visual_uploaded_indices.is_empty(),
+            "second frame with no new dirty indices should upload nothing"
+        );
+    }
 }

--- a/rust/src/render.rs
+++ b/rust/src/render.rs
@@ -1520,4 +1520,155 @@ mod tests {
         );
         assert_eq!(intents[0].1.source, "dc:attack");
     }
+
+    // ── sync_terrain_tilemap signal tests ─────────────────────────────────
+
+    #[derive(Resource, Default)]
+    struct SendTerrainDirty(bool);
+
+    fn maybe_send_terrain_dirty(
+        mut writer: MessageWriter<TerrainDirtyMsg>,
+        mut flag: ResMut<SendTerrainDirty>,
+    ) {
+        if flag.0 {
+            writer.write(TerrainDirtyMsg);
+            flag.0 = false;
+        }
+    }
+
+    fn setup_terrain_sync_app() -> App {
+        use crate::world::{Biome, WorldCell};
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.insert_resource(TimeUpdateStrategy::ManualDuration(
+            std::time::Duration::from_secs_f32(1.0),
+        ));
+        app.add_message::<TerrainDirtyMsg>();
+        app.insert_resource(SendTerrainDirty(false));
+        // 4x4 grid with distinct biomes
+        let mut grid = WorldGrid::default();
+        grid.width = 4;
+        grid.height = 4;
+        grid.cell_size = 64.0;
+        grid.cells = vec![
+            WorldCell {
+                terrain: Biome::Forest,
+                original_terrain: Biome::Forest,
+            };
+            16
+        ];
+        // Set cell (0,0) to Water (tileset_index = 8)
+        grid.cells[0] = WorldCell {
+            terrain: Biome::Water,
+            original_terrain: Biome::Water,
+        };
+        app.insert_resource(grid);
+        app.add_systems(
+            FixedUpdate,
+            (maybe_send_terrain_dirty, sync_terrain_tilemap).chain(),
+        );
+        app.update();
+        app.update();
+        app
+    }
+
+    #[test]
+    fn sync_terrain_noop_without_message() {
+        let mut app = setup_terrain_sync_app();
+        // Spawn a chunk with tile_data pre-filled with tileset index 99 (sentinel)
+        let sentinel_tile = TileData::from_tileset_index(99);
+        let tile_data = vec![Some(sentinel_tile); 4 * 4];
+        app.world_mut().spawn((
+            TerrainChunk,
+            TilemapChunkTileData(tile_data),
+            TerrainChunkRegion {
+                origin_x: 0,
+                origin_y: 0,
+                chunk_w: 4,
+                chunk_h: 4,
+            },
+        ));
+        // Run WITHOUT sending TerrainDirtyMsg
+        app.update();
+        let mut query = app.world_mut().query::<&TilemapChunkTileData>();
+        let tile_data = query.single(app.world()).unwrap().0.clone();
+        assert_eq!(
+            tile_data[0].as_ref().map(|t| t.tileset_index),
+            Some(99),
+            "tile_data should be unchanged when no TerrainDirtyMsg is sent"
+        );
+    }
+
+    #[test]
+    fn sync_terrain_updates_tiles_with_message() {
+        use crate::world::Biome;
+        let mut app = setup_terrain_sync_app();
+        // Spawn a chunk with tile_data pre-filled with sentinel index 99
+        let sentinel_tile = TileData::from_tileset_index(99);
+        let tile_data = vec![Some(sentinel_tile); 4 * 4];
+        app.world_mut().spawn((
+            TerrainChunk,
+            TilemapChunkTileData(tile_data),
+            TerrainChunkRegion {
+                origin_x: 0,
+                origin_y: 0,
+                chunk_w: 4,
+                chunk_h: 4,
+            },
+        ));
+        // Send TerrainDirtyMsg and run
+        app.insert_resource(SendTerrainDirty(true));
+        app.update();
+        let mut query = app.world_mut().query::<&TilemapChunkTileData>();
+        let tile_data = query.single(app.world()).unwrap().0.clone();
+        // Cell (0,0) = Water => tileset_index should be 8 (not 99 sentinel)
+        let actual = tile_data[0].as_ref().map(|t| t.tileset_index);
+        assert_ne!(
+            actual,
+            Some(99),
+            "tile_data should be updated after TerrainDirtyMsg"
+        );
+        assert_eq!(
+            actual,
+            Some(Biome::Water.tileset_index(0)),
+            "cell (0,0) should have Water tileset index"
+        );
+    }
+
+    #[test]
+    fn sync_terrain_noop_on_subsequent_frame_without_new_message() {
+        let mut app = setup_terrain_sync_app();
+        let sentinel_tile = TileData::from_tileset_index(99);
+        let tile_data = vec![Some(sentinel_tile); 4 * 4];
+        app.world_mut().spawn((
+            TerrainChunk,
+            TilemapChunkTileData(tile_data),
+            TerrainChunkRegion {
+                origin_x: 0,
+                origin_y: 0,
+                chunk_w: 4,
+                chunk_h: 4,
+            },
+        ));
+        // First run WITH message
+        app.insert_resource(SendTerrainDirty(true));
+        app.update();
+        // Manually reset tile_data back to sentinel to detect re-run
+        {
+            let mut query = app.world_mut().query::<&mut TilemapChunkTileData>();
+            let mut tile_data = query.single_mut(app.world_mut()).unwrap();
+            for t in tile_data.0.iter_mut() {
+                *t = Some(TileData::from_tileset_index(99));
+            }
+        }
+        // Second run WITHOUT message -- tile_data should remain sentinel
+        app.update();
+        let mut query = app.world_mut().query::<&TilemapChunkTileData>();
+        let tile_data = query.single(app.world()).unwrap().0.clone();
+        assert_eq!(
+            tile_data[0].as_ref().map(|t| t.tileset_index),
+            Some(99),
+            "sync_terrain_tilemap should be no-op on subsequent frame without TerrainDirtyMsg"
+        );
+    }
 }

--- a/rust/src/world.rs
+++ b/rust/src/world.rs
@@ -3211,7 +3211,136 @@ fn generate_terrain_worldmap(grid: &mut WorldGrid) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::entity_map::BuildingInstance;
+    use crate::messages::BuildingGridDirtyMsg;
+    use crate::resources::EntityMap;
     use bevy::ecs::system::RunSystemOnce;
+    use bevy::time::TimeUpdateStrategy;
+
+    // ── rebuild_building_grid_system signal tests ──────────────────────────
+
+    #[derive(bevy::prelude::Resource, Default)]
+    struct SendBuildingGridDirty(bool);
+
+    fn maybe_send_building_grid_dirty(
+        mut writer: MessageWriter<BuildingGridDirtyMsg>,
+        mut flag: bevy::prelude::ResMut<SendBuildingGridDirty>,
+    ) {
+        if flag.0 {
+            writer.write(BuildingGridDirtyMsg);
+            flag.0 = false;
+        }
+    }
+
+    fn setup_rebuild_app() -> App {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.insert_resource(EntityMap::default());
+        app.add_message::<BuildingGridDirtyMsg>();
+        app.insert_resource(SendBuildingGridDirty(false));
+        app.insert_resource(TimeUpdateStrategy::ManualDuration(
+            std::time::Duration::from_secs_f32(1.0),
+        ));
+        let mut grid = WorldGrid::default();
+        grid.width = 16;
+        grid.height = 16;
+        grid.cell_size = 64.0;
+        grid.cells = vec![WorldCell::default(); 16 * 16];
+        app.insert_resource(grid);
+        app.add_systems(
+            FixedUpdate,
+            (maybe_send_building_grid_dirty, rebuild_building_grid_system).chain(),
+        );
+        app.update();
+        app.update();
+        app
+    }
+
+    #[test]
+    fn rebuild_building_grid_noop_without_message() {
+        let mut app = setup_rebuild_app();
+        let pos = Vec2::new(32.0, 32.0);
+        app.world_mut()
+            .resource_mut::<EntityMap>()
+            .add_instance(BuildingInstance {
+                kind: BuildingKind::Farm,
+                position: pos,
+                slot: 1,
+                town_idx: 0,
+                faction: 1,
+            });
+        // Run WITHOUT sending a BuildingGridDirtyMsg
+        app.update();
+        let em = app.world().resource::<EntityMap>();
+        let mut found = false;
+        em.for_each_nearby(pos, 200.0, |_, _| found = true);
+        assert!(
+            !found,
+            "spatial should not be initialized without BuildingGridDirtyMsg"
+        );
+    }
+
+    #[test]
+    fn rebuild_building_grid_initializes_spatial_with_message() {
+        let mut app = setup_rebuild_app();
+        let pos = Vec2::new(32.0, 32.0);
+        app.world_mut()
+            .resource_mut::<EntityMap>()
+            .add_instance(BuildingInstance {
+                kind: BuildingKind::Farm,
+                position: pos,
+                slot: 1,
+                town_idx: 0,
+                faction: 1,
+            });
+        // Send the message and run
+        app.insert_resource(SendBuildingGridDirty(true));
+        app.update();
+        let em = app.world().resource::<EntityMap>();
+        let mut found = false;
+        em.for_each_nearby(pos, 200.0, |_, _| found = true);
+        assert!(
+            found,
+            "spatial should be rebuilt after BuildingGridDirtyMsg"
+        );
+    }
+
+    #[test]
+    fn rebuild_building_grid_preserves_spatial_on_subsequent_frame() {
+        // After a message-triggered rebuild, subsequent frames without a message
+        // must NOT clear the spatial grid. Buildings found after the first rebuild
+        // must remain findable on the next frame.
+        let mut app = setup_rebuild_app();
+        let pos_a = Vec2::new(32.0, 32.0);
+        app.world_mut()
+            .resource_mut::<EntityMap>()
+            .add_instance(BuildingInstance {
+                kind: BuildingKind::Farm,
+                position: pos_a,
+                slot: 1,
+                town_idx: 0,
+                faction: 1,
+            });
+        // First run WITH message -> spatial initialized and building A indexed
+        app.insert_resource(SendBuildingGridDirty(true));
+        app.update();
+        // Verify building A is in spatial after the rebuild
+        {
+            let em = app.world().resource::<EntityMap>();
+            let mut found = false;
+            em.for_each_nearby(pos_a, 200.0, |_, _| found = true);
+            assert!(found, "building A should be found after first rebuild");
+        }
+        // Second run WITHOUT message -- spatial must NOT be cleared
+        app.update();
+        let em = app.world().resource::<EntityMap>();
+        let mut still_found = false;
+        em.for_each_nearby(pos_a, 200.0, |_, _| still_found = true);
+        assert!(
+            still_found,
+            "spatial should be preserved on subsequent frame without BuildingGridDirtyMsg"
+        );
+    }
 
     #[test]
     fn road_blocked_on_forest_biome() {


### PR DESCRIPTION
## Summary

- Adds regression tests for `rebuild_building_grid_system`, `sync_terrain_tilemap`, and `build_visual_upload` verifying each is a no-op when its signal message is absent
- Tests verify correct work when message is present and state preservation on subsequent frames
- `invalidate_paths_on_building_change` tests already existed in `systems/pathfinding.rs` (4 tests)

## Tests added

**`world.rs`** (`BuildingGridDirtyMsg` / `rebuild_building_grid_system`):
- `rebuild_building_grid_noop_without_message` - spatial not initialized when no message
- `rebuild_building_grid_initializes_spatial_with_message` - spatial rebuilt and building found
- `rebuild_building_grid_preserves_spatial_on_subsequent_frame` - spatial retained without new message

**`gpu.rs`** (`MarkVisualDirty` / `build_visual_upload`):
- `build_visual_upload_noop_without_dirty_indices` - empty upload when no dirty indices
- `build_visual_upload_only_processes_dirty_indices` - only dirty slot appears in uploaded_indices
- `build_visual_upload_noop_on_second_frame_without_new_dirty` - no upload on frame with no new dirty

**`render.rs`** (`TerrainDirtyMsg` / `sync_terrain_tilemap`):
- `sync_terrain_noop_without_message` - tile_data unchanged when no message
- `sync_terrain_updates_tiles_with_message` - tile_data updated from WorldGrid biomes
- `sync_terrain_noop_on_subsequent_frame_without_new_message` - tile_data unchanged on second frame

## Test plan

- [x] `cargo clippy --release -- -D warnings` passes
- [x] `cargo test --lib --release` passes (305 tests, 0 failures)
- [x] All 13 new tests pass (9 new + 4 pre-existing pathfinding)
- [x] Compliance verified against docs/performance.md, docs/k8s.md, docs/authority.md

## Compliance

- **performance.md**: tests verify event-driven system pattern (no work without signal) — directly guards the anti-pattern of unconditional per-frame rebuilds
- **k8s.md**: no def/instance/controller changes; tests only cover system gating behavior
- **authority.md**: no changes to data ownership; tests read/write only test-local ECS state