### PR TITLE
refactor: create GameLog SystemParam bundle for combat_log + game_time + timings

### DIFF
--- a/rust/src/systemparams.rs
+++ b/rust/src/systemparams.rs
@@ -3,6 +3,7 @@
 use bevy::ecs::system::SystemParam;
 use bevy::prelude::*;
 
+use crate::messages::CombatLogMsg;
 use crate::messages::DirtyWriters;
 use crate::messages::GpuUpdateMsg;
 use crate::resources::*;
@@ -169,6 +170,16 @@ impl WorldState<'_> {
             gpu_updates,
         )
     }
+}
+
+/// Flat bundle for systems that write combat log entries with game time and profiling context.
+/// Contains: combat_log (message writer), game_time (read-only game clock), timings (profiler).
+/// No nested SystemParam bundles -- all fields are primitive system params.
+#[derive(SystemParam)]
+pub struct GameLog<'w> {
+    pub combat_log: MessageWriter<'w, CombatLogMsg>,
+    pub game_time: Res<'w, GameTime>,
+    pub timings: Res<'w, SystemTimings>,
 }
 
 /// Mutable economy resources shared by gameplay systems.

--- a/rust/src/systems/economy/mod.rs
+++ b/rust/src/systems/economy/mod.rs
@@ -15,7 +15,7 @@ use crate::constants::{
 };
 use crate::messages::{CombatLogMsg, GpuUpdate, GpuUpdateMsg, SpawnNpcMsg};
 use crate::resources::*;
-use crate::systemparams::{EconomyState, WorldState};
+use crate::systemparams::{EconomyState, GameLog, WorldState};
 use crate::systems::ai_player::{AiKind, AiPersonality, AiPlayer, AiPlayerState};
 use crate::systems::stats::UPGRADES;
 use crate::world::{self, Biome, BuildingKind, WorldData};
@@ -501,16 +501,15 @@ pub fn farm_visual_system(
 /// and spawns replacements via GpuSlotPool + SpawnNpcMsg.
 /// Only runs when game_time.hour_ticked is true.
 pub fn spawner_respawn_system(
-    game_time: Res<GameTime>,
+    mut game_log: GameLog,
     entity_map: ResMut<EntityMap>,
     mut slots: ResMut<GpuSlotPool>,
     mut spawn_writer: MessageWriter<SpawnNpcMsg>,
     world_data: Res<WorldData>,
-    mut combat_log: MessageWriter<CombatLogMsg>,
     mut dirty_writers: crate::messages::DirtyWriters,
     mut spawner_q: Query<(&mut SpawnerState, Option<&MinerHomeConfig>)>,
 ) {
-    if !game_time.hour_ticked {
+    if !game_log.game_time.hour_ticked {
         return;
     }
 
@@ -588,12 +587,12 @@ pub fn spawner_respawn_system(
                     dirty_writers.mining.write(crate::messages::MiningDirtyMsg);
                 }
 
-                combat_log.write(CombatLogMsg {
+                game_log.combat_log.write(CombatLogMsg {
                     kind: CombatEventKind::Spawn,
                     faction,
-                    day: game_time.day(),
-                    hour: game_time.hour(),
-                    minute: game_time.minute(),
+                    day: game_log.game_time.day(),
+                    hour: game_log.game_time.hour(),
+                    minute: game_log.game_time.minute(),
                     message: format!("{} respawned from {}", job_name, building_name),
                     location: None,
                 });
@@ -1055,8 +1054,7 @@ pub fn endless_system(
     mut migration_state: ResMut<MigrationState>,
     mut world_state: WorldState,
     mut ai_state: ResMut<AiPlayerState>,
-    mut combat_log: MessageWriter<CombatLogMsg>,
-    game_time: Res<GameTime>,
+    mut game_log: GameLog,
     time: Res<Time>,
     config: Res<world::WorldGenConfig>,
     mut res: MigrationResources,
@@ -1087,7 +1085,7 @@ pub fn endless_system(
     if let Some(mg) = &mut migration_state.active {
         if let Some(boat_slot) = mg.boat_slot {
             let dir = (mg.settle_target - mg.boat_pos).normalize_or_zero();
-            mg.boat_pos += dir * BOAT_SPEED * game_time.delta(&time);
+            mg.boat_pos += dir * BOAT_SPEED * game_log.game_time.delta(&time);
 
             res.gpu_updates.write(GpuUpdateMsg(GpuUpdate::SetPosition {
                 idx: boat_slot,
@@ -1154,12 +1152,12 @@ pub fn endless_system(
                 mg.boat_slot = None;
 
                 let kind_str = if mg.is_raider { "Raiders" } else { "Settlers" };
-                combat_log.write(CombatLogMsg {
+                game_log.combat_log.write(CombatLogMsg {
                     kind: CombatEventKind::Raid,
                     faction: -1,
-                    day: game_time.day(),
-                    hour: game_time.hour(),
-                    minute: game_time.minute(),
+                    day: game_log.game_time.day(),
+                    hour: game_log.game_time.hour(),
+                    minute: game_log.game_time.minute(),
                     message: format!("{} have landed!", kind_str),
                     location: Some(mg.boat_pos),
                 });
@@ -1229,12 +1227,12 @@ pub fn endless_system(
                 } else {
                     "rival faction"
                 };
-                combat_log.write(CombatLogMsg {
+                game_log.combat_log.write(CombatLogMsg {
                     kind: CombatEventKind::Raid,
                     faction: -1,
-                    day: game_time.day(),
-                    hour: game_time.hour(),
-                    minute: game_time.minute(),
+                    day: game_log.game_time.day(),
+                    hour: game_log.game_time.hour(),
+                    minute: game_log.game_time.minute(),
                     message: format!("The migrating {} was wiped out!", kind_str),
                     location: None,
                 });
@@ -1351,12 +1349,12 @@ pub fn endless_system(
         } else {
             "rival faction"
         };
-        combat_log.write(CombatLogMsg {
+        game_log.combat_log.write(CombatLogMsg {
             kind: CombatEventKind::Raid,
             faction: -1,
-            day: game_time.day(),
-            hour: game_time.hour(),
-            minute: game_time.minute(),
+            day: game_log.game_time.day(),
+            hour: game_log.game_time.hour(),
+            minute: game_log.game_time.minute(),
             message: format!("A {} has settled nearby!", kind_str),
             location: Some(mg.settle_target),
         });
@@ -1373,7 +1371,7 @@ pub fn endless_system(
         return;
     }
 
-    let dt_hours = game_time.delta(&time) / game_time.seconds_per_hour;
+    let dt_hours = game_log.game_time.delta(&time) / game_log.game_time.seconds_per_hour;
     for spawn in &mut endless.pending_spawns {
         spawn.delay_remaining -= dt_hours;
     }
@@ -1450,12 +1448,12 @@ pub fn endless_system(
     } else {
         "rival faction"
     };
-    combat_log.write(CombatLogMsg {
+    game_log.combat_log.write(CombatLogMsg {
         kind: CombatEventKind::Raid,
         faction: -1,
-        day: game_time.day(),
-        hour: game_time.hour(),
-        minute: game_time.minute(),
+        day: game_log.game_time.day(),
+        hour: game_log.game_time.hour(),
+        minute: game_log.game_time.minute(),
         message: format!("A {} approaches from the {}!", kind_str, direction),
         location: Some(Vec2::new(spawn_x, spawn_y)),
     });

--- a/rust/src/systems/economy/tests.rs
+++ b/rust/src/systems/economy/tests.rs
@@ -1372,6 +1372,7 @@ fn setup_spawner_app() -> App {
             kind: crate::constants::TownKind::Player,
         }],
     });
+    app.insert_resource(crate::resources::SystemTimings::default());
     // Register all message types needed by DirtyWriters + system
     app.add_message::<SpawnNpcMsg>();
     app.add_message::<CombatLogMsg>();
@@ -1473,6 +1474,33 @@ fn spawner_assigns_uid_after_spawn() {
     assert!(
         (ss.respawn_timer - (-1.0)).abs() < 0.01,
         "timer should reset to -1.0"
+    );
+}
+
+/// Regression test: GameLog bundle -- spawner still writes combat log entries after migration.
+/// This test would FAIL if spawner_respawn_system stopped calling game_log.combat_log.write().
+#[test]
+fn spawner_respawn_writes_combat_log_entry() {
+    use crate::resources::CombatLog;
+    use crate::systems::drain::drain_combat_log;
+
+    let mut app = setup_spawner_app();
+    app.insert_resource(CombatLog::default());
+    app.add_message::<CombatLogMsg>();
+    app.add_systems(FixedUpdate, drain_combat_log);
+
+    // Set game_time.total_seconds > 0 so the log write runs (not just game start)
+    app.world_mut().resource_mut::<GameTime>().total_seconds = 100.0;
+
+    // Timer at 1.0 triggers a spawn (and a combat log write) on hour tick
+    add_spawner_building(&mut app, 5000, BuildingKind::ArcherHome, 1.0);
+    app.world_mut().resource_mut::<GameTime>().hour_ticked = true;
+    app.update();
+
+    let log = app.world().resource::<CombatLog>();
+    assert!(
+        !log.iter_all().next().is_none(),
+        "spawner_respawn_system should write a combat log entry via GameLog bundle"
     );
 }
 

--- a/rust/src/systems/spawn.rs
+++ b/rust/src/systems/spawn.rs
@@ -3,9 +3,10 @@
 use bevy::prelude::*;
 
 use crate::components::*;
-use crate::messages::{CombatLogMsg, GpuUpdate, GpuUpdateMsg, SpawnNpcMsg};
-use crate::messages::{DirtyWriters, MiningDirtyMsg, SquadsDirtyMsg};
-use crate::resources::{CombatEventKind, EntityMap, FactionStats, GameTime, PopulationStats};
+use crate::messages::{CombatLogMsg, DirtyWriters, MiningDirtyMsg, SquadsDirtyMsg};
+use crate::messages::{GpuUpdate, GpuUpdateMsg, SpawnNpcMsg};
+use crate::resources::{CombatEventKind, EntityMap, FactionStats, PopulationStats};
+use crate::systemparams::GameLog;
 use crate::systems::economy::*;
 use crate::systems::stats::{CombatConfig, resolve_combat_stats};
 use crate::world::BuildingKind;
@@ -325,8 +326,7 @@ pub fn spawn_npc_system(
     mut pop_stats: ResMut<PopulationStats>,
     mut faction_stats: ResMut<FactionStats>,
     mut gpu_updates: MessageWriter<GpuUpdateMsg>,
-    game_time: Res<GameTime>,
-    mut combat_log: MessageWriter<CombatLogMsg>,
+    mut game_log: GameLog,
     combat_config: Res<CombatConfig>,
     town_access: crate::systemparams::TownAccess,
     mut dirty_writers: DirtyWriters,
@@ -368,14 +368,14 @@ pub fn spawn_npc_system(
             dirty_writers.squads.write(SquadsDirtyMsg);
         }
 
-        if game_time.total_hours() > 0 {
+        if game_log.game_time.total_hours() > 0 {
             let job_str = crate::job_name(msg.job);
-            combat_log.write(CombatLogMsg {
+            game_log.combat_log.write(CombatLogMsg {
                 kind: CombatEventKind::Spawn,
                 faction: msg.faction,
-                day: game_time.day(),
-                hour: game_time.hour(),
-                minute: game_time.minute(),
+                day: game_log.game_time.day(),
+                hour: game_log.game_time.hour(),
+                minute: game_log.game_time.minute(),
                 message: format!("{} #{} spawned", job_str, msg.slot_idx),
                 location: None,
             });


### PR DESCRIPTION
## Summary

- Adds `GameLog` SystemParam bundle to `systemparams.rs` with flat `combat_log`, `game_time`, `timings` fields (no nested bundles)
- Migrates `spawner_respawn_system`, `endless_system`, and `spawn_npc_system` from individual `MessageWriter<CombatLogMsg>` + `Res<GameTime>` params to `GameLog`
- Adds `SystemTimings` resource to spawner test fixture (required by the new bundle)
- Adds regression test `spawner_respawn_writes_combat_log_entry` that would FAIL if the system stopped writing combat log entries

Note: bundle placed in `systemparams.rs` (not `resources.rs` as specified in issue) -- `messages.rs` already imports from `resources.rs` (`GameConfig`), so importing `CombatLogMsg` into `resources.rs` would create a circular dependency.

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy --release -- -D warnings` passes (0 warnings)
- [x] `cargo test --release` -- 297 tests pass
- [x] New regression test `spawner_respawn_writes_combat_log_entry` verifies combat log entries produced via `GameLog` bundle

Closes #139