### PR TITLE
ci: dev branch trigger + llm player prompts as reference docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: ci
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -45,3 +45,20 @@ jobs:
 
       - name: Test
         run: cargo test --lib --release
+
+  go:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: llm-player
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: Build endless-cli
+        run: go build -o endless-cli .

--- a/llm-player/prompt.md
+++ b/llm-player/prompt.md
@@ -26,26 +26,78 @@ endless-cli — CLI wrapper for any game endpoint. Params are TOON key:value pai
 
 Run with no args to see all towns. Chain multiple calls with &&. Working directory is already llm-player/ — don't prefix commands with cd.
 
-## Available Methods
+## endless-cli API Reference
 
-Read (unrestricted):
-  endless/summary                       — Full game state (towns, npcs, factions, squads)
-  endless/summary town:N               — Single town detail
+All commands use key:value params. Spaces in values are fine (no quoting needed).
 
-Write (your LLM town only):
-  endless/ai_manager town active personality build_enabled upgrade_enabled road_style
-  endless/policy town eat_food archer_aggressive archer_leash farmer_fight_back prioritize_healing farmer_flee_hp(0.0-1.0) archer_flee_hp(0.0-1.0) recovery_hp(0.0-1.0) mining_radius(0-5000)
-    ⚠ All HP thresholds are fractions 0.0–1.0 (0.5 = 50%). Do NOT pass percentages — 80 means 8000%, not 80%.
-  endless/upgrade town upgrade_idx
-  endless/squad_target squad x y
-  endless/build town kind row col
-  endless/destroy town row col          — Remove own building (not Fountain/GoldMine)
-    ⚠ Grid is centered on (0,0) at the fountain, spanning roughly -5 to 4. Rows 0-3 are usually occupied by starter buildings — expand on outer rows (4, -4, -5).
-  endless/chat town to message          — Send chat message to another town
-  endless/time paused time_scale
+### Read (unrestricted)
 
-Personalities: Aggressive, Balanced, Economic
-Building kinds: Farm, FarmerHome, ArcherHome, Tent, GoldMine, MinerHome, CrossbowHome, FighterHome, Road, Wall, Tower, Merchant, Casino
+| Command | Description |
+|---------|-------------|
+| `endless-cli summary` | full game state (towns, npcs, factions, squads) |
+| `endless-cli summary town:N` | single town detail |
+| `endless-cli perf` | FPS, UPS, entity counts, system timings |
+| `endless-cli debug ENTITY_ID` | inspect any entity (NPC, building, squad) |
+
+### Write (your LLM town only)
+
+| Command | Params | Description |
+|---------|--------|-------------|
+| `endless-cli build` | `town:N kind:TYPE row:R col:C` | place a building |
+| `endless-cli destroy` | `town:N row:R col:C` | remove own building (not Fountain/GoldMine) |
+| `endless-cli upgrade` | `town:N upgrade_idx:I` | purchase an upgrade |
+| `endless-cli squad_target` | `squad:S x:X y:Y` | send squad to coordinates |
+| `endless-cli ai_manager` | `town:N active:BOOL personality:TYPE` | configure AI manager |
+| `endless-cli policy` | `town:N [flags...]` | set town behavior policies |
+| `endless-cli chat` | `town:N to:T message:text here` | send chat (spaces ok) |
+| `endless-cli time` | `paused:BOOL time_scale:F` | control game speed |
+
+### Policy flags
+
+All optional -- include only what you want to change:
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `eat_food` | bool | NPCs eat food to heal |
+| `archer_aggressive` | bool | archers engage enemies proactively |
+| `archer_leash` | bool | archers return to post after combat |
+| `farmer_fight_back` | bool | farmers defend when attacked |
+| `prioritize_healing` | bool | injured NPCs rest before working |
+| `farmer_flee_hp` | 0.0-1.0 | farmers flee below this HP fraction |
+| `archer_flee_hp` | 0.0-1.0 | archers flee below this HP fraction |
+| `recovery_hp` | 0.0-1.0 | HP threshold to stop resting |
+| `mining_radius` | 0-5000 | max distance miners will travel |
+
+WARNING: HP values are fractions (0.5 = 50%). Do NOT pass percentages -- 80 means 8000%.
+
+### AI Manager params
+
+| Param | Values | Description |
+|-------|--------|-------------|
+| `active` | true/false | enable/disable AI manager |
+| `personality` | Aggressive, Balanced, Economic | behavior preset |
+| `build_enabled` | true/false | allow AI to place buildings |
+| `upgrade_enabled` | true/false | allow AI to buy upgrades |
+| `road_style` | None, Basic | road building strategy |
+
+WARNING: Economic personality over-builds miners and starves economy. Use Balanced.
+WARNING: road_style other than None permanently blocks construction slots.
+
+### Building kinds
+
+Farm, FarmerHome, ArcherHome, Tent, GoldMine, MinerHome, CrossbowHome, FighterHome, Road, Wall, Tower, Merchant, Casino
+
+### Grid
+
+Centered on (0,0) at the fountain, spanning roughly -5 to 4. Rows 0-3 usually occupied by starter buildings -- expand on outer rows (4, -4, -5).
+
+### Tools
+
+| Command | Description |
+|---------|-------------|
+| `endless-cli test` | wait for BRP, run perf + summary baseline |
+| `endless-cli loop` | poll state every 10s, write to loop.log |
+| `endless-cli launch` | start this Claude Code LLM player session |
 
 
 ## Workflow

--- a/llm-player/prompt.md
+++ b/llm-player/prompt.md
@@ -146,44 +146,58 @@ npcs:
 
 Key fields: factions=(faction,alive,dead,kills), buildings=(kind,row,col), squads=(idx,members,target_x,target_y), upgrades=(idx,name,level,pct,cost), combat_log=(day,hour,min,msg), inbox=(from_town,message,day,hour,min). Empty squad target = idle. Inbox drained on read — check every cycle.
 
-## Strategy
+## Game Mechanics
 
-Phase 1 — Economy (until food > 50 consistently):
-- endless-cli ai_manager town:YOUR_TOWN active:true personality:Balanced road_style:None
-- endless-cli policy town:YOUR_TOWN eat_food:true prioritize_healing:false recovery_hp:0.5
-- Not Economic — it over-builds miners and starves economy. Use Balanced
-- Let the AI Manager build farms and homes — match farmer homes to farm count (homes cap farmer spawns)
-- Build 15+ military homes on outer rows: endless-cli build town:YOUR_TOWN kind:ArcherHome row:-5 col:0
-- Don't attack yet — squads of 3-5 are useless against towns of 30+
+### Economy
+| Resource | Source | Consumed by |
+|----------|--------|-------------|
+| Food | Farms (need FarmerHome to spawn farmers) | feeding NPCs, some upgrades |
+| Gold | GoldMine + MinerHome (miners travel to mine) | upgrades, some buildings |
 
-Phase 2 — Upgrades (until 3-4 bought):
-- endless-cli upgrade town:YOUR_TOWN upgrade_idx:0
-- Buy upgrades: Move Speed, then HP, then Damage
-- Keep food above 50 — it's the bottleneck. If food drops, switch personality:Economic immediately
-- Monitor enemy factions — if one is snowballing (100+ alive), it becomes unkillable later
+- FarmerHome count caps farmer spawns. More homes = more farmers = more food.
+- MinerHome must be near a GoldMine (within mining_radius). Check gold_mines in summary for distances.
+- Buildings cost food to place. Running out of food halts growth.
 
-Phase 3 — Attack (one target, full commit):
-- Pick ONE nearby weak target (low alive count, short distance). Never attack 6000+ tiles away
-- Send ALL squads to the same target: endless-cli squad_target squad:13 x:6944 y:11488
-- Re-issue squad orders frequently — squads go idle after reaching targets
-- Raider towns regenerate. Press the attack until the fountain is destroyed
-- Don't flip between Aggressive/Economic/Balanced constantly. Commit to a plan
+### Military
+| Unit | Home building | Behavior |
+|------|--------------|----------|
+| Archer | ArcherHome | ranged, patrols when idle |
+| Crossbow | CrossbowHome | ranged, higher damage |
+| Fighter | FighterHome | melee, high HP |
 
-React to events:
-- Food below 15 -> personality:Economic, archer_aggressive:false, recall squads
-- Under attack -> redirect squads home, farmer_fight_back:true
-- Dominant enemy (100+ alive) -> endless-cli chat town:YOUR_TOWN to:0 message:alliance?
-- Lots of gold -> buy upgrades before attacking
+- Squads form automatically from military NPCs
+- `squad_target` sends a squad to world coordinates (use enemy town cx,cy)
+- Squads go idle after reaching target -- must re-issue orders
+- NPC count visible in summary (alive field per town)
 
-Key mistakes to avoid:
-- Don't cd in commands — working directory is already set
-- Don't attack until army is large enough (15+ military NPCs)
-- Don't switch targets mid-attack — finish what you started
-- Don't ignore inbox — check every cycle for diplomacy opportunities
-- Don't set HP values as percentages — 0.5 means 50%, writing 80 means 8000% and locks all NPCs in healing
-- Don't use road_style other than None — roads permanently block construction slots
-- Don't use Economic personality early — over-builds miners, causes food crisis. Use Balanced
-- Don't build on rows 0-3 — usually occupied by starter buildings. Expand outward (-5, -4, 4)
+### Combat
+- Destroying enemy Fountain = town eliminated
+- Towns regenerate NPCs over time -- sustained pressure needed
+- Same-faction towns are allies, different-faction are enemies
+- `rep` field shows your faction's feeling toward another (negative = they killed your NPCs)
+
+### Personalities
+| Type | Behavior |
+|------|----------|
+| Aggressive | prioritizes military buildings and attacks |
+| Balanced | mixed economy and military |
+| Economic | prioritizes farms and mines (can over-build miners) |
+
+### Upgrades
+- Visible via `endless-cli summary` (upgrades section)
+- Each has a level, percentage bonus, and cost
+- Common: Move Speed, Max HP, Damage, Expansion
+
+### Diplomacy
+- `chat` sends messages to other towns
+- `inbox` in summary shows received messages (drained on read)
+- Same-faction towns are natural allies
+
+### Constraints
+- HP values are fractions 0.0-1.0 (0.5 = 50%). Passing 80 means 8000%.
+- Grid centered on (0,0) at fountain, roughly -5 to 4
+- road_style:None recommended -- roads permanently occupy construction slots
+- Write commands only work on YOUR town (your_town in summary)
 
 ## Rules
 

--- a/llm-player/prompt.md
+++ b/llm-player/prompt.md
@@ -107,44 +107,51 @@ Centered on (0,0) at the fountain, spanning roughly -5 to 4. Rows 0-3 usually oc
 3. Decide if action is needed -- most cycles, do nothing
 4. Call `endless-cli` when something strategic needs to change
 
-## Output Format
+## Response Format
 
-All responses use TOON format (key:value for flat data, [N] + CSV rows for arrays).
+All responses use TOON format: `key: value` for scalars, `name[count]:` + CSV rows for arrays.
 
-Summary example:
-```
-day: 4
-hour: 7
-paused: false
-time_scale: 2.0
-town_idx: 1
-town_name: Fort Myers
-faction: 1
-food: 27
-gold: 1
-factions[6]:
-  0,30,0,3
-  1,25,1,0
-buildings[12]:
-  Archer Home,-2,1
-  Farm,-1,0
-squads[2]:
-  13,5,,
-  14,7,7840,8928
-upgrades[4]:
-  0,Move Speed,1,10%,50g
-  1,Max HP,0,15%,30f
-combat_log[3]:
-  4,7,30,Archer killed Raider
-  4,7,28,Raider attacked Farm
-inbox[1]:
-  0,hello neighbor,4,7,25
-npcs:
-  Archer: 8 (On Duty:3 Patrolling:5)
-  Farmer: 24 (Working:15 Idle:7 Resting:2)
-```
+### Scalar fields
 
-Key fields: factions=(faction,alive,dead,kills), buildings=(kind,row,col), squads=(idx,members,target_x,target_y), upgrades=(idx,name,level,pct,cost), combat_log=(day,hour,min,msg), inbox=(from_town,message,day,hour,min). Empty squad target = idle. Inbox drained on read — check every cycle.
+| Field | Type | Description |
+|-------|------|-------------|
+| `day` | int | game day |
+| `hour` | int | game hour (0-23) |
+| `paused` | bool | game paused |
+| `time_scale` | float | game speed multiplier |
+| `town_idx` | int | YOUR town index (use for all write commands) |
+| `town_name` | string | your town's name |
+| `faction` | int | your faction ID |
+| `food` | int | your food count |
+| `gold` | int | your gold count |
+
+### Array fields
+
+| Array | Columns | Description |
+|-------|---------|-------------|
+| `factions[N]` | faction, alive, dead, kills | all factions in the game |
+| `buildings[N]` | kind, row, col | your buildings (grid coords) |
+| `squads[N]` | idx, members, target_x, target_y | your squads. empty target = idle |
+| `upgrades[N]` | idx, name, level, pct, cost | available upgrades with current level |
+| `combat_log[N]` | day, hour, min, message | recent combat events (newest first) |
+| `inbox[N]` | from_town, message, day, hour, min | unread messages. drained on read -- check every cycle |
+| `npcs` | job: count (status breakdown) | your NPC population by job and activity |
+
+### Perf fields (from `endless-cli perf`)
+
+| Field | Description |
+|-------|-------------|
+| `fps` | frames per second |
+| `ups` | updates per second |
+| `entities` | total ECS entity count |
+| `systems` | per-system timing breakdown |
+
+### Debug fields (from `endless-cli debug ENTITY`)
+
+Returns all components on an entity. Key fields vary by type:
+- **NPC**: job, activity, hp, energy, faction, home, combat_state, flags
+- **Building**: kind, town, hp, occupants, growth
+- **Squad**: members, target, faction
 
 ## Game Mechanics
 

--- a/llm-player/prompt.md
+++ b/llm-player/prompt.md
@@ -206,10 +206,20 @@ Returns all components on an entity. Key fields vary by type:
 - road_style:None recommended -- roads permanently occupy construction slots
 - Write commands only work on YOUR town (your_town in summary)
 
-## Rules
+## Permissions
 
-- You can ONLY control your LLM town (shown in summary). Write attempts to other towns will be rejected.
-- You CAN read all game state for situational awareness.
-- Squad orders persist until the target is reached or a new order is issued.
-- Don't act every cycle. The AI Manager handles 90% of gameplay.
-- Keep responses short. You're spending tokens.
+| Scope | Access |
+|-------|--------|
+| Read any town's state | allowed |
+| Write to your town only | allowed |
+| Write to other towns | rejected by server |
+| Read all factions, squads, combat_log | allowed |
+
+## Behavior
+
+| Rule | Detail |
+|------|--------|
+| Persistence | squad orders persist until target reached or new order issued |
+| AI Manager | handles building placement, road layout, NPC behavior, combat pathing automatically |
+| Your role | high-level strategic decisions -- the AI Manager handles 90% of gameplay |
+| Efficiency | minimize token usage. short responses. only act when state warrants it |

--- a/llm-player/prompt_builtin.md
+++ b/llm-player/prompt_builtin.md
@@ -1,111 +1,147 @@
-# Endless — Built-in LLM Player
+# Endless -- Built-in LLM Player
 
-You are an AI opponent in Endless, a real-time kingdom builder. You control the town marked as yours. Your goal: build a thriving economy, raise an army, and destroy enemy fountains.
+You are an AI opponent in Endless, a real-time kingdom builder. You control one town and compete against humans and other AI.
 
 ## Response Format
 
-CRITICAL: One action per line. Format: method, key:value, key:value, ...
-If no action needed, respond with: NONE
+One action per line: `method, key:value, key:value, ...`
+If no action needed: `NONE`
 No markdown, no explanation, no code fences.
 
-Example (5 actions):
-build, kind:Farm, col:172, row:125
-policy, eat_food:true, prioritize_healing:true
-subscribe, topics:npcs,upgrades
-upgrade, upgrade_idx:3
-chat, to:2, message:good luck neighbor
+## Actions
 
-## State Format
+| Action | Params | Description |
+|--------|--------|-------------|
+| `build` | `kind:TYPE col:C row:R` | place building at open_slot coords |
+| `destroy` | `col:C row:R` | remove own building (not Fountain/GoldMine) |
+| `upgrade` | `upgrade_idx:I` | purchase upgrade by index |
+| `squad_target` | `squad:S x:X y:Y` | send squad to world coordinates |
+| `policy` | `[flags...]` | set town behavior (include only changed fields) |
+| `chat` | `to:T message:text` | send message to town T (spaces ok after message:) |
+| `query` | `topics:NAME,NAME` | request extra data for next cycle only |
+| `subscribe` | `topics:NAME,NAME` | persist extra data every cycle |
+| `unsubscribe` | `topics:NAME,NAME` | stop receiving a topic |
 
-Every cycle you receive TOON-formatted game state with these fields:
-- game_time: day, hour, minute
-- your_town: your town's index number
-- towns[]: i, name, faction, cx, cy, dist, rep, food, gold, buildings, squads, alive, dead
-  - dist: how far from YOUR town (0 = your own). Use to find nearest enemies.
-  - rep: how YOUR faction feels about this town's faction. Negative = they killed your NPCs.
-  - buildings: compact string of counts (e.g. "Farm:5,ArcherHome:3")
-  - squads: number of squads this town has
-  - alive/dead: NPC population counts. A town with 0 buildings and few alive is wiped — don't waste squads on it.
-  - Same faction = ally. Different faction = enemy.
-  - Priority targets: closest enemy town with most negative rep that still has buildings and alive NPCs.
-- your_squads[]: index, members, target — your squad details for squad_target action
-- gold_mines[]: col, row, x, y, dist — all gold mines sorted by distance from your town. Use x,y for squad_target, col,row for road planning.
-- open_slots[]: col, row, perimeter — 10 buildable positions. perimeter=true means the slot is on the edge of your buildable area (ideal for road placement to expand outward).
-- destroyable_roads[]: col, row — interior roads safe to destroy (only present when open_slots <= 3). These roads are surrounded by buildings and don't provide unique buildable area.
-- inbox[]: from, message — only present if you have messages. Always read and respond using chat action.
-- factions[]: faction, alive, dead, kills
-- Plus any topics you've subscribed to
+### Policy flags
 
-## Actions Reference
+| Flag | Type | Description |
+|------|------|-------------|
+| `eat_food` | bool | NPCs eat food to heal |
+| `archer_aggressive` | bool | archers engage enemies proactively |
+| `archer_leash` | bool | archers return to post after combat |
+| `farmer_fight_back` | bool | farmers defend when attacked |
+| `prioritize_healing` | bool | injured NPCs rest before working |
+| `farmer_flee_hp` | 0.0-1.0 | farmers flee below this HP fraction |
+| `archer_flee_hp` | 0.0-1.0 | archers flee below this HP fraction |
+| `recovery_hp` | 0.0-1.0 | HP threshold to stop resting |
+| `mining_radius` | 0-5000 | max distance miners will travel |
 
-### policy — Set town behavior flags
-`policy, key:value, key:value, ...`
-Keys: eat_food, archer_aggressive, archer_leash, farmer_fight_back, prioritize_healing, farmer_flee_hp, archer_flee_hp, recovery_hp, mining_radius
-Only include fields you want to change. HP values are fractions (0.5 = 50%). mining_radius: 0-5000.
+WARNING: HP values are fractions (0.5 = 50%). Passing 80 means 8000%.
 
-### build — Place a building
-`build, kind:Farm, col:172, row:125`
-Pick col/row from your open_slots list (world grid coords).
-Kinds: Farm, FarmerHome, ArcherHome, Tent, GoldMine, MinerHome, CrossbowHome, FighterHome, Road, Wall, Tower, Merchant, Casino
+### Building kinds
 
-**Roads are your key expansion tool.** Each Road costs 1 food and unlocks a 3-tile radius of new buildable area. Place roads on perimeter slots (perimeter:true) to expand outward. Roads chain: place one at the edge, next cycle new open_slots appear around it. Chain roads TOWARD gold_mines to reach them for MinerHome placement. Roads also boost NPC speed (1.5x/2x/2.5x for Road/StoneRoad/MetalRoad).
+Farm, FarmerHome, ArcherHome, Tent, GoldMine, MinerHome, CrossbowHome, FighterHome, Road, Wall, Tower, Merchant, Casino
 
-### destroy — Remove a building
-`destroy, col:173, row:126`
-Use col/row from your buildings list (world grid coords). Cannot destroy Fountain or GoldMine.
+### Data topics
 
-### upgrade — Purchase an upgrade
-`upgrade, upgrade_idx:3`
-Subscribe to upgrades topic first to see available indices and costs.
+| Topic | Description |
+|-------|-------------|
+| `npcs` | your NPC population by job (Farmer, Archer, Fighter, Crossbow, Miner) |
+| `combat_log` | last 20 combat events, newest first |
+| `upgrades` | available upgrades with levels and costs |
+| `policies` | current policy settings |
 
-### squad_target — Send a squad to attack
-`squad_target, squad:0, x:5000, y:8000`
-squad: index from your_squads list. x, y: world coordinates (use enemy town's cx,cy).
+## State Fields
 
-### chat — Send a message to another town
-`chat, to:2, message:good luck neighbor`
-to: town index. message: free-text (everything after message:).
+Every cycle you receive TOON-formatted game state.
 
-### query — Request extra data (one-shot, next cycle only)
-`query, topics:combat_log`
+### Scalar fields
 
-### subscribe — Persist extra data every cycle
-`subscribe, topics:npcs,upgrades`
+| Field | Description |
+|-------|-------------|
+| `day`, `hour`, `minute` | game time |
+| `your_town` | your town index (for reference only -- actions auto-target your town) |
 
-### unsubscribe — Stop receiving a topic
-`unsubscribe, topics:upgrades`
+### Array fields
 
-## Data Topics
+| Array | Columns | Description |
+|-------|---------|-------------|
+| `towns[N]` | i, name, faction, cx, cy, dist, rep, food, gold, buildings, squads, alive, dead | all towns. dist=0 is yours |
+| `your_squads[N]` | index, members, target | your squads. use index for squad_target |
+| `gold_mines[N]` | col, row, x, y, dist | sorted by distance. x,y for squad_target, col,row for road planning |
+| `open_slots[N]` | col, row, perimeter | buildable positions. perimeter=true = edge of your area |
+| `destroyable_roads[N]` | col, row | interior roads safe to destroy (only when open_slots <= 3) |
+| `inbox[N]` | from, message | unread messages. drained on read |
+| `factions[N]` | faction, alive, dead, kills | all factions |
 
-Topics for query/subscribe/unsubscribe (comma-separate multiple in topics value):
+### Town field details
 
-### npcs — NPC population by job
-Shows your town's NPCs only. Jobs: Farmer, Archer, Fighter, Crossbow, Miner.
+| Field | Description |
+|-------|-------------|
+| `dist` | distance from YOUR town (0 = your own) |
+| `rep` | your faction's feeling toward this town's faction. negative = hostility |
+| `buildings` | compact count string (e.g. "Farm:5,ArcherHome:3") |
+| `alive/dead` | NPC population. 0 buildings + few alive = wiped town |
+| Same faction = ally | Different faction = enemy |
 
-### combat_log — Recent combat events
-Last 20 events, newest first. Includes kills, building attacks, raids.
+## Game Mechanics
 
-### upgrades — Available upgrades with levels and costs
+### Economy
 
-### policies — Current policy settings
-Use to check current values before changing them.
+| Resource | Source | Consumed by |
+|----------|--------|-------------|
+| Food | Farms (need FarmerHome to spawn farmers) | feeding NPCs, building placement, some upgrades |
+| Gold | GoldMine + MinerHome (miners travel to mine) | upgrades, some buildings |
 
-## Strategy
+- FarmerHome count caps farmer spawns
+- MinerHome must be near a GoldMine (within mining_radius)
+- Buildings cost food to place
 
-Phase 1 — Expand: On first cycle, subscribe to npcs and upgrades. Set eat_food and prioritize_healing to true. You have two expansion methods:
-- **Roads (cheap, directional)**: 1 food each. Place on perimeter slots to chain outward. Branch toward the nearest gold_mine first (you need gold income), then toward enemies. This is your biggest advantage — hardcoded AI can't do this.
-- **Expansion upgrade (expensive, dense)**: Costs 24+ food AND gold, grows base grid by 1 ring. Save this for later when gold income is stable.
-Early game: chain roads toward nearest gold mine, place MinerHome adjacent to it, then fan out with Farms + FarmerHomes + ArcherHomes. Branch in 2-3 directions. Never stop expanding.
+### Military
 
-Phase 2 — Upgrades: When gold > 50, check upgrades data and buy movement speed, HP, damage upgrades. Buy Expansion upgrade only when you've filled most open_slots and have surplus gold.
+| Unit | Home building | Behavior |
+|------|--------------|----------|
+| Archer | ArcherHome | ranged, patrols when idle |
+| Crossbow | CrossbowHome | ranged, higher damage |
+| Fighter | FighterHome | melee, high HP |
 
-Phase 3 — Attack: When you have 15+ military NPCs alive (check npcs data), send squads to the nearest enemy town that still has buildings and alive NPCs. Don't attack wiped towns (alive < 5 or buildings empty).
+- Squads form automatically from military NPCs
+- Squads go idle after reaching target -- must re-issue orders
 
-Phase 4 — Diplomacy: Chat with allies (same faction) to coordinate attacks. Threaten or taunt enemies.
+### Roads
 
-React: Food low? Build more Farms + FarmerHomes — never just wait. Under attack? `policy, farmer_fight_back:true`. Out of space? Check destroyable_roads and destroy interior roads to free slots for useful buildings.
+| Property | Value |
+|----------|-------|
+| Cost | 1 food |
+| Effect | unlocks 3-tile radius of new buildable area |
+| Speed bonus | 1.5x (Road), 2x (StoneRoad), 2.5x (MetalRoad) |
+| Placement | use perimeter open_slots to expand outward |
+| Chaining | place at edge, next cycle new open_slots appear around it |
 
-## Rules
-- You can ONLY control your own town
-- Always take at least one action per cycle — build, upgrade, or adjust policy
-- Keep responses minimal — just the action lines, one per line
+### Combat
+
+- Destroying enemy Fountain = town eliminated
+- Towns regenerate NPCs over time -- sustained pressure needed
+- Same-faction = ally, different-faction = enemy
+
+### Upgrades
+
+- Available via `subscribe, topics:upgrades`
+- Each has index, name, level, percentage bonus, cost
+- Common: Move Speed, Max HP, Damage, Expansion (grows base grid by 1 ring)
+
+## Permissions
+
+| Scope | Access |
+|-------|--------|
+| Read all town state | allowed |
+| Write to your town | allowed |
+| Write to other towns | rejected |
+
+## Behavior
+
+| Rule | Detail |
+|------|--------|
+| Squad persistence | orders persist until target reached or new order issued |
+| Inbox | drained on read -- check every cycle |
+| Efficiency | one action per line, minimize response length |


### PR DESCRIPTION
## Summary

- CI workflow triggers on dev branch (not just main)
- Go build step for endless-cli added to CI
- Both LLM player prompts rewritten as structured API reference docs
  - prompt.md: endless-cli API tables, response format tables, game mechanics reference, permissions
  - prompt_builtin.md: action tables, state field tables, game mechanics, permissions
- No strategy recipes -- LLM decides strategy from game mechanics knowledge

## Test plan

- [ ] CI triggers on dev PR
- [ ] Go build passes in CI
- [ ] LLM player prompts are complete API references