### PR TITLE
feat: HP bar display mode toggle (Off / When Damaged / Always)

### DIFF
--- a/rust/assets/shaders/npc_render.wgsl
+++ b/rust/assets/shaders/npc_render.wgsl
@@ -74,7 +74,8 @@ struct Camera {
     bldg_layers: f32,
     extras_cols: f32,
     lod_zoom: f32,
-    _pad: u32,
+    // HP bar display mode: 0=Off, 1=WhenDamaged, 2=Always
+    hp_bar_mode: u32,
 };
 @group(1) @binding(0) var<uniform> camera: Camera;
 
@@ -403,8 +404,8 @@ fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
     }
 
     // Health bar in bottom 15% of sprite (quad_uv.y > 0.85 = bottom rows)
-    // Show when damaged (health < 99%) — applies to NPCs and farm growth bars
-    let show_hp_bar = in.health < 0.99;
+    // hp_bar_mode: 0=Off, 1=WhenDamaged (show when health < 99%), 2=Always
+    let show_hp_bar = (camera.hp_bar_mode == 2u) || (camera.hp_bar_mode == 1u && in.health < 0.99);
     if in.quad_uv.y > 0.85 && show_hp_bar {
         var bar_color = vec4<f32>(0.2, 0.2, 0.2, 1.0);
 
@@ -432,8 +433,12 @@ fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
         discard;
     }
 
-    // Keep HP bar visible by masking equipment pixels in bottom strip.
-    if in.health >= 0.99 && in.quad_uv.y > 0.85 && in.atlas_id < 0.5 {
+    // Mask sprite texture pixels in bottom strip when not showing HP bar.
+    // In Off mode (hp_bar_mode==0): always discard so no stray sprite pixels show.
+    // In WhenDamaged mode: discard only for full-health NPCs (damaged ones returned early above).
+    // In Always mode: never reached here for bottom strip (all NPCs return early above).
+    let full_hp = in.health >= 0.99;
+    if (full_hp || camera.hp_bar_mode == 0u) && in.quad_uv.y > 0.85 && in.atlas_id < 0.5 {
         discard;
     }
 

--- a/rust/assets/shaders/npc_render.wgsl
+++ b/rust/assets/shaders/npc_render.wgsl
@@ -395,8 +395,10 @@ fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
         return vec4<f32>(tex_color.rgb * in.color.rgb, tex_color.a);
     }
 
-    // Carried item sprite (atlas_id 1): original colors, no grayscale tint
-    if in.atlas_id >= 0.5 && in.health >= 0.99 {
+    // Carried item sprite (atlas_id 1): original colors, no grayscale tint.
+    // Skip this early-return in Always mode so full-health NPC equipment sprites fall through
+    // to the HP bar block and don't cover the bar drawn by the base sprite layer.
+    if in.atlas_id >= 0.5 && in.health >= 0.99 && camera.hp_bar_mode != 2u {
         // Carried world item path with original texture colors.
         let tex_color = textureSample(world_texture, world_sampler, in.uv);
         if tex_color.a < 0.1 { discard; }

--- a/rust/src/npc_render.rs
+++ b/rust/src/npc_render.rs
@@ -244,7 +244,8 @@ pub struct CameraUniform {
     pub bldg_layers: f32,
     pub extras_cols: f32,
     pub lod_zoom: f32,
-    pub _pad: u32,
+    /// HP bar display mode: 0=Off, 1=WhenDamaged, 2=Always.
+    pub hp_bar_mode: u32,
 }
 
 /// Bind group for camera uniform.
@@ -662,6 +663,7 @@ fn extract_camera_state(
         zoom,
         viewport: Vec2::new(window.width(), window.height()),
         lod_zoom: user_settings.lod_transition,
+        hp_bar_mode: user_settings.hp_bar_mode.as_u32(),
     });
 }
 
@@ -1959,7 +1961,7 @@ fn prepare_npc_camera_bind_group(
             + crate::constants::autotile_total_extra_layers()) as f32,
         extras_cols: 4.0,
         lod_zoom: camera_state.lod_zoom,
-        _pad: 0,
+        hp_bar_mode: camera_state.hp_bar_mode,
     };
 
     let mut buffer = UniformBuffer::from(uniform);

--- a/rust/src/render.rs
+++ b/rust/src/render.rs
@@ -80,6 +80,8 @@ pub struct CameraState {
     pub zoom: f32,
     pub viewport: Vec2,
     pub lod_zoom: f32,
+    /// HP bar display mode: 0=Off, 1=WhenDamaged, 2=Always.
+    pub hp_bar_mode: u32,
 }
 
 const EDGE_PAN_MARGIN: f32 = 8.0;

--- a/rust/src/settings.rs
+++ b/rust/src/settings.rs
@@ -9,6 +9,29 @@ use crate::resources::PolicySet;
 
 const SETTINGS_VERSION: u32 = 14;
 
+/// Controls when NPC HP bars are displayed.
+#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug, Default)]
+pub enum HpBarMode {
+    /// Never show HP bars.
+    Off,
+    /// Show HP bars only when the NPC is damaged (HP < max). Current/default behavior.
+    #[default]
+    WhenDamaged,
+    /// Always show HP bars on all living NPCs.
+    Always,
+}
+
+impl HpBarMode {
+    /// Maps to the u32 constant used in the GPU shader (camera uniform `hp_bar_mode`).
+    pub fn as_u32(self) -> u32 {
+        match self {
+            Self::Off => 0,
+            Self::WhenDamaged => 1,
+            Self::Always => 2,
+        }
+    }
+}
+
 /// Controls which NPCs have their activity logged in `NpcLogCache`.
 #[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug, Default)]
 pub enum NpcLogMode {
@@ -731,6 +754,9 @@ pub struct UserSettings {
     /// LLM player cycle interval in seconds.
     #[serde(default = "default_llm_interval")]
     pub llm_interval: f32,
+    /// When to display NPC HP bars.
+    #[serde(default)]
+    pub hp_bar_mode: HpBarMode,
 }
 
 fn default_llm_interval() -> f32 {
@@ -909,6 +935,7 @@ impl Default for UserSettings {
             left_panel_tab: String::new(),
             collapsed_sections: Vec::new(),
             llm_interval: 20.0,
+            hp_bar_mode: HpBarMode::WhenDamaged,
         }
     }
 }
@@ -1045,5 +1072,44 @@ pub fn load_settings() -> UserSettings {
             settings
         }
         Err(_) => UserSettings::default(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hp_bar_mode_default_is_when_damaged() {
+        let settings = UserSettings::default();
+        assert_eq!(
+            settings.hp_bar_mode,
+            HpBarMode::WhenDamaged,
+            "default hp_bar_mode must be WhenDamaged to preserve existing behavior"
+        );
+    }
+
+    #[test]
+    fn hp_bar_mode_when_damaged_shader_value_matches_current_behavior() {
+        // WhenDamaged maps to 1 in the shader -- the existing always-on value.
+        // If this changes, the shader constant must change too.
+        assert_eq!(HpBarMode::WhenDamaged.as_u32(), 1u32);
+        assert_eq!(HpBarMode::Off.as_u32(), 0u32);
+        assert_eq!(HpBarMode::Always.as_u32(), 2u32);
+    }
+
+    #[test]
+    fn hp_bar_mode_serde_roundtrip() {
+        // Verify serde(default) round-trips correctly.
+        let json = r#"{"hp_bar_mode":"Always"}"#;
+        let partial: std::collections::BTreeMap<String, serde_json::Value> =
+            serde_json::from_str(json).unwrap();
+        let mode: HpBarMode = serde_json::from_value(partial["hp_bar_mode"].clone()).unwrap();
+        assert_eq!(mode, HpBarMode::Always);
+
+        // Missing key should deserialize to WhenDamaged (default).
+        let mode_default: HpBarMode =
+            serde_json::from_value(serde_json::Value::Null).unwrap_or_default();
+        assert_eq!(mode_default, HpBarMode::WhenDamaged);
     }
 }

--- a/rust/src/ui/mod.rs
+++ b/rust/src/ui/mod.rs
@@ -309,6 +309,21 @@ pub fn settings_panel_ui(
                             ui.add(egui::Slider::new(&mut settings.lod_transition, 0.1..=2.0).text("LOD Transition"))
                                 .on_hover_text("Below this zoom level, sprites render as flat rectangles.");
                             ui.small("Lower values keep detailed sprites visible longer.");
+                            ui.add_space(6.0);
+
+                            ui.label("HP Bar Display");
+                            let hp_mode = &mut settings.hp_bar_mode;
+                            ui.horizontal(|ui| {
+                                use crate::settings::HpBarMode;
+                                if ui.selectable_label(*hp_mode == HpBarMode::Off, "Off").clicked() { *hp_mode = HpBarMode::Off; }
+                                if ui.selectable_label(*hp_mode == HpBarMode::WhenDamaged, "When Damaged").clicked() { *hp_mode = HpBarMode::WhenDamaged; }
+                                if ui.selectable_label(*hp_mode == HpBarMode::Always, "Always").clicked() { *hp_mode = HpBarMode::Always; }
+                            });
+                            match settings.hp_bar_mode {
+                                crate::settings::HpBarMode::Off => { ui.small("HP bars never shown. Cleaner visuals at scale."); }
+                                crate::settings::HpBarMode::WhenDamaged => { ui.small("HP bars shown only on damaged NPCs. Default behavior."); }
+                                crate::settings::HpBarMode::Always => { ui.small("HP bars always visible. Easier to track army health."); }
+                            }
                         }
                         PauseSettingsTab::Controls => {
                             if let Some(action) = *rebinding_action {


### PR DESCRIPTION
Closes #145

## Summary

- `HpBarMode` enum added to `settings.rs`: `Off`, `WhenDamaged` (default), `Always`
- `hp_bar_mode` field added to `UserSettings` with `#[serde(default)]` for backward compat
- `hp_bar_mode` threaded through `CameraState` -> `CameraUniform` -> GPU shader each frame
- `npc_render.wgsl` Camera struct updated (replaces `_pad: u32` with `hp_bar_mode: u32`); shader `show_hp_bar` logic updated for all three modes
- Settings UI toggle added in Camera tab using `selectable_label` pattern (same as NpcLogMode)
- Unit tests: default value, shader constant mapping, serde roundtrip

## Compliance

- **k8s.md**: No new entity types or registry changes. `HpBarMode` is a pure settings enum.
- **authority.md**: HP bar visibility is a render-only concern. Health data is CPU-authoritative and unchanged; only the shader display logic is gated by the mode.
- **performance.md**: Off mode: zero HP bar rendering overhead (full green bar skip, no bottom-strip pixels). The mode check is a single `u32` compare in the shader hot path — no per-NPC CPU overhead. No O(n^2) patterns introduced.

## Test plan
- [ ] `cargo clippy --release -- -D warnings` passes (verified locally)
- [ ] `cargo check` passes (verified locally)
- [ ] Unit tests pass on CI: `hp_bar_mode_default_is_when_damaged`, `hp_bar_mode_when_damaged_shader_value_matches_current_behavior`, `hp_bar_mode_serde_roundtrip`
- [ ] WhenDamaged mode: identical to current behavior (default value = 1, same shader condition)
- [ ] Off mode: no HP bars rendered for any NPC
- [ ] Always mode: HP bars shown on all living NPCs including full-health