### PR TITLE
fix: reduce rock node density (issue 162)

### DIFF
--- a/rust/src/systems/pathfinding.rs
+++ b/rust/src/systems/pathfinding.rs
@@ -1276,12 +1276,18 @@ mod tests {
         place_wall(&mut entity_map, 3, 3, wall_slot);
         grid.sync_building_costs(&entity_map);
         let idx = 3 * grid.width + 3;
-        assert_eq!(grid.pathfind_costs[idx], 0, "wall cell should be impassable after placement");
+        assert_eq!(
+            grid.pathfind_costs[idx], 0,
+            "wall cell should be impassable after placement"
+        );
 
         entity_map.remove_by_slot(wall_slot);
         grid.sync_building_costs(&entity_map);
         let terrain_cost = crate::world::terrain_base_cost(crate::world::Biome::Grass);
-        assert_eq!(grid.pathfind_costs[idx], terrain_cost, "wall cell should revert to terrain cost after removal");
+        assert_eq!(
+            grid.pathfind_costs[idx], terrain_cost,
+            "wall cell should revert to terrain cost after removal"
+        );
     }
 
     /// Regression: two sequential sync calls produce correct cumulative costs.
@@ -1292,18 +1298,31 @@ mod tests {
         place_wall(&mut entity_map, 2, 2, 401);
         grid.sync_building_costs(&entity_map);
         let wall_idx = 2 * grid.width + 2;
-        assert_eq!(grid.pathfind_costs[wall_idx], 0, "wall should be impassable");
+        assert_eq!(
+            grid.pathfind_costs[wall_idx], 0,
+            "wall should be impassable"
+        );
 
         entity_map.add_instance(crate::resources::BuildingInstance {
             kind: crate::world::BuildingKind::Road,
             position: Vec2::new(5.0 * 64.0 + 32.0, 5.0 * 64.0 + 32.0),
-            slot: 402, town_idx: 0, faction: 0,
+            slot: 402,
+            town_idx: 0,
+            faction: 0,
         });
         grid.sync_building_costs(&entity_map);
-        assert_eq!(grid.pathfind_costs[wall_idx], 0, "wall should remain impassable after second sync");
+        assert_eq!(
+            grid.pathfind_costs[wall_idx], 0,
+            "wall should remain impassable after second sync"
+        );
         let road_idx = 5 * grid.width + 5;
-        let road_cost = crate::world::BuildingKind::Road.road_pathfind_cost().unwrap();
-        assert_eq!(grid.pathfind_costs[road_idx], road_cost, "road cell should have road cost after second sync");
+        let road_cost = crate::world::BuildingKind::Road
+            .road_pathfind_cost()
+            .unwrap();
+        assert_eq!(
+            grid.pathfind_costs[road_idx], road_cost,
+            "road cell should have road cost after second sync"
+        );
     }
 
     /// Regression test for issue #203: only pass changed cells to rebuild_chunks.
@@ -1318,22 +1337,52 @@ mod tests {
         assert_eq!(after_first.len(), 1, "one building cell after first sync");
         let wall_idx = 5 * grid.width + 5;
         assert_eq!(after_first[0], wall_idx, "wall cell recorded");
-        let rebuild_after_add = grid.hpa_cache.as_ref().map(|c| c.rebuild_count).unwrap_or(0);
-        assert_eq!(rebuild_after_add, 1, "rebuild_chunks called once on wall add");
+        let rebuild_after_add = grid
+            .hpa_cache
+            .as_ref()
+            .map(|c| c.rebuild_count)
+            .unwrap_or(0);
+        assert_eq!(
+            rebuild_after_add, 1,
+            "rebuild_chunks called once on wall add"
+        );
 
         grid.sync_building_costs(&entity_map);
         let after_second: Vec<usize> = grid.dirty_cost_cells().to_vec();
         assert_eq!(after_second.len(), 1, "same one cell after no-op sync");
-        assert!(grid.pathfind_costs[wall_idx] == 0, "wall cell must be impassable after no-op sync");
-        let rebuild_after_noop = grid.hpa_cache.as_ref().map(|c| c.rebuild_count).unwrap_or(0);
-        assert_eq!(rebuild_after_noop, 1, "rebuild_chunks must NOT be called on no-op sync (issue #203 regression)");
+        assert!(
+            grid.pathfind_costs[wall_idx] == 0,
+            "wall cell must be impassable after no-op sync"
+        );
+        let rebuild_after_noop = grid
+            .hpa_cache
+            .as_ref()
+            .map(|c| c.rebuild_count)
+            .unwrap_or(0);
+        assert_eq!(
+            rebuild_after_noop, 1,
+            "rebuild_chunks must NOT be called on no-op sync (issue #203 regression)"
+        );
 
         let empty_map = EntityMap::default();
         grid.sync_building_costs(&empty_map);
-        assert!(grid.dirty_cost_cells().is_empty(), "no building cells after wall removed");
-        assert!(grid.pathfind_costs[wall_idx] > 0, "wall cell passable after removal");
-        let rebuild_after_remove = grid.hpa_cache.as_ref().map(|c| c.rebuild_count).unwrap_or(0);
-        assert_eq!(rebuild_after_remove, 2, "rebuild_chunks called once more on wall removal");
+        assert!(
+            grid.dirty_cost_cells().is_empty(),
+            "no building cells after wall removed"
+        );
+        assert!(
+            grid.pathfind_costs[wall_idx] > 0,
+            "wall cell passable after removal"
+        );
+        let rebuild_after_remove = grid
+            .hpa_cache
+            .as_ref()
+            .map(|c| c.rebuild_count)
+            .unwrap_or(0);
+        assert_eq!(
+            rebuild_after_remove, 2,
+            "rebuild_chunks called once more on wall removal"
+        );
     }
 
     #[test]

--- a/rust/src/world/tests.rs
+++ b/rust/src/world/tests.rs
@@ -485,6 +485,9 @@ fn worldmap_generates_corridors_and_ice_caps() {
         "should have >10% water, got {:.1}%",
         water as f64 / total * 100.0
     );
+    // 10% threshold is conservative; worldmap targets ~45% land on non-ice cells (~34% total).
+    // Fixed seed makes this deterministic -- the threshold just guards against
+    // degenerate generation (all water/ice) not specific land percentages.
     assert!(
         land as f64 / total >= 0.15,
         "should have >=15% land, got {:.1}%",

--- a/rust/src/world/tests.rs
+++ b/rust/src/world/tests.rs
@@ -368,12 +368,20 @@ fn resource_nodes_follow_biomes_spacing_and_occupied_cells() {
                     &mut gpu_updates,
                 );
 
-                // Density 1.0: every Forest/Rock cell gets a node, except occupied cells
+                // TreeNodes: one per Forest cell, except occupied cells.
+                // RockNodes: only cells where col % ROCK_NODE_STEP == 0 && row % ROCK_NODE_STEP == 0.
+                // Rock cells: (0,2), (1,2), (3,2).
+                //   (0,2): col=0, row=2 -- both even -> placed
+                //   (1,2): col=1 -- odd -> skipped
+                //   (3,2): col=3 -- odd -> skipped
                 assert_eq!(
                     tree_count, 3,
                     "3 of 4 forest cells should get TreeNode (one occupied by Waypoint)"
                 );
-                assert_eq!(rock_count, 3, "all 3 rock cells should get RockNode");
+                assert_eq!(
+                    rock_count, 1,
+                    "only step-aligned rock cells (col%2==0 && row%2==0) should get RockNode"
+                );
 
                 assert_eq!(
                     entity_map.get_at_grid(0, 0).map(|b| b.kind),
@@ -382,7 +390,7 @@ fn resource_nodes_follow_biomes_spacing_and_occupied_cells() {
                 assert_eq!(
                     entity_map.get_at_grid(1, 0).map(|b| b.kind),
                     Some(BuildingKind::TreeNode),
-                    "adjacent forest cell should also get a TreeNode at density 1.0"
+                    "adjacent forest cell should get TreeNode (tree density unchanged)"
                 );
                 assert_eq!(
                     entity_map.get_at_grid(3, 0).map(|b| b.kind),
@@ -394,18 +402,23 @@ fn resource_nodes_follow_biomes_spacing_and_occupied_cells() {
                     "occupied cell should keep existing building"
                 );
 
+                // (0,2): step-aligned, should have RockNode
                 assert_eq!(
                     entity_map.get_at_grid(0, 2).map(|b| b.kind),
-                    Some(BuildingKind::RockNode)
+                    Some(BuildingKind::RockNode),
+                    "step-aligned rock cell should get RockNode"
                 );
+                // (1,2): col=1 is not step-aligned, should be empty
                 assert_eq!(
                     entity_map.get_at_grid(1, 2).map(|b| b.kind),
-                    Some(BuildingKind::RockNode),
-                    "adjacent rock cell should also get RockNode at density 1.0"
+                    None,
+                    "non-step-aligned rock cell should be skipped by density reduction"
                 );
+                // (3,2): col=3 is not step-aligned, should be empty
                 assert_eq!(
                     entity_map.get_at_grid(3, 2).map(|b| b.kind),
-                    Some(BuildingKind::RockNode)
+                    None,
+                    "non-step-aligned rock cell should be skipped by density reduction"
                 );
 
                 assert_eq!(entity_map.get_at_grid(2, 1).map(|b| b.kind), None);

--- a/rust/src/world/worldgen.rs
+++ b/rust/src/world/worldgen.rs
@@ -155,6 +155,11 @@ impl WorldGenConfig {
 // RESOURCE NODE SPAWNING
 // ============================================================================
 
+/// Minimum cell step for RockNode placement. Only cells where both row and col
+/// are divisible by this value receive a node, reducing rock density to ~25%
+/// of biome coverage and keeping count comparable to TreeNodes.
+const ROCK_NODE_STEP: usize = 2;
+
 pub(crate) fn spawn_resource_nodes(
     _config: &WorldGenConfig,
     grid: &mut WorldGrid,
@@ -166,14 +171,19 @@ pub(crate) fn spawn_resource_nodes(
     let mut tree_count = 0usize;
     let mut rock_count = 0usize;
 
-    // Density 1.0: every Forest cell gets a TreeNode, every Rock cell gets a RockNode.
-    // No spacing check needed -- one entity per grid cell, no overlap possible.
+    // TreeNodes: one per Forest cell (naturally distributed).
+    // RockNodes: every ROCK_NODE_STEP cells in both axes to avoid solid-band density.
     for row in 0..grid.height {
         for col in 0..grid.width {
             let idx = row * grid.width + col;
             let kind = match grid.cells[idx].terrain {
                 Biome::Forest => BuildingKind::TreeNode,
-                Biome::Rock => BuildingKind::RockNode,
+                Biome::Rock => {
+                    if col % ROCK_NODE_STEP != 0 || row % ROCK_NODE_STEP != 0 {
+                        continue;
+                    }
+                    BuildingKind::RockNode
+                }
                 _ => continue,
             };
             if entity_map.has_building_at(col as i32, row as i32) {


### PR DESCRIPTION
## Summary
- Adds `ROCK_NODE_STEP = 2` constant controlling RockNode placement spacing
- Only places RockNodes where both `col % ROCK_NODE_STEP == 0` and `row % ROCK_NODE_STEP == 0`, reducing density to ~25% (~35K nodes vs 142K)
- TreeNode behavior unchanged (still placed on every Forest cell)
- Updates existing regression test to verify the new density behavior fails if change is reverted

## Compliance
- docs/performance.md: no hot-path changes; spawn_resource_nodes runs once at worldgen, not per-frame
- docs/k8s.md: no new entity types or registry changes; BuildingKind::RockNode unchanged
- docs/authority.md: no GPU/CPU authority changes

## Test plan
- [x] `cargo clippy --release -- -D warnings` passes (0 warnings)
- [x] `cargo test --release` passes (307/307 tests)
- [x] `world::tests::resource_nodes_follow_biomes_spacing_and_occupied_cells` updated to verify rock_count=1 for step-gated grid; would fail if ROCK_NODE_STEP removed