### PR TITLE
fix: TerrainDirtyMsg unit struct -> struct with tile field

### DIFF
--- a/rust/src/render.rs
+++ b/rust/src/render.rs
@@ -1703,7 +1703,7 @@ mod tests {
         mut flag: ResMut<SendTerrainDirty>,
     ) {
         if flag.0 {
-            writer.write(TerrainDirtyMsg);
+            writer.write(TerrainDirtyMsg { tile: None });
             flag.0 = false;
         }
     }


### PR DESCRIPTION
Fixes #171

## Change

`render.rs:1706` constructed `TerrainDirtyMsg` as a unit struct, but it has a `tile: Option<(u32, u32)>` field since messages.rs:76-78.

Fixed to: `writer.write(TerrainDirtyMsg { tile: None });`

## Tests

- `cargo clippy --release -- -D warnings` passes
- `cargo check` passes
- Regression test: n/a per issue (compile fix only, no behavior change)

## Compliance

- docs/k8s.md: no Def/Instance/Controller changes
- docs/authority.md: no authority boundary changes
- docs/performance.md: no hot-path impact (single field addition in message construction)