### PR TITLE
chore: enforce unwrap() discipline with clippy lint

### DIFF
--- a/rust/benches/system_bench.rs
+++ b/rust/benches/system_bench.rs
@@ -16,8 +16,8 @@ use endless::gpu::populate_gpu_state;
 use endless::gpu::{EntityGpuState, ProjBufferWrites};
 use endless::messages::*;
 use endless::resources::*;
-use endless::systems::stats;
 use endless::systems::ai_player::{AiSnapshotDirty, RoadStyle};
+use endless::systems::stats;
 use endless::systems::{
     AiKind, AiPersonality, AiPlayer, AiPlayerConfig, AiPlayerState, advance_waypoints_system,
     ai_decision_system, arrival_system, attack_system, building_tower_system,

--- a/rust/src/constants/npcs.rs
+++ b/rust/src/constants/npcs.rs
@@ -865,9 +865,9 @@ pub const ACTIVITY_REGISTRY: &[ActivityDef] = &[
 ];
 
 pub fn activity_def(kind: ActivityKind) -> &'static ActivityDef {
-    #[allow(clippy::unwrap_used)] // registry is complete by construction; missing entry is a bug
+    // registry covers all ActivityKind variants; missing entry is a compile-time oversight
     ACTIVITY_REGISTRY
         .iter()
         .find(|d| d.activity == kind)
-        .unwrap()
+        .expect("ACTIVITY_REGISTRY must contain all ActivityKind variants")
 }

--- a/rust/src/constants/npcs.rs
+++ b/rust/src/constants/npcs.rs
@@ -865,6 +865,7 @@ pub const ACTIVITY_REGISTRY: &[ActivityDef] = &[
 ];
 
 pub fn activity_def(kind: ActivityKind) -> &'static ActivityDef {
+    #[allow(clippy::unwrap_used)] // registry is complete by construction; missing entry is a bug
     ACTIVITY_REGISTRY
         .iter()
         .find(|d| d.activity == kind)

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -5,6 +5,7 @@
     clippy::type_complexity,    // Bevy Query types are inherently complex
     clippy::collapsible_if,     // Nested ifs are often clearer in game logic
 )]
+#![deny(clippy::unwrap_used)]
 
 // ============================================================================
 // MODULES

--- a/rust/src/systems/combat.rs
+++ b/rust/src/systems/combat.rs
@@ -893,6 +893,7 @@ pub fn building_tower_system(
         .collect();
 
     for &(slot, src, faction, xp, ref levels, levels_len, entity, kind, equip_bonus) in &towers {
+        #[allow(clippy::unwrap_used)] // tower_stats is guaranteed present for tower building kinds
         let base = crate::constants::building_def(kind).tower_stats.unwrap();
         let level = crate::systems::stats::level_from_xp(xp);
         let mut stats = crate::systems::stats::resolve_tower_instance_stats(

--- a/rust/src/systems/combat.rs
+++ b/rust/src/systems/combat.rs
@@ -893,8 +893,10 @@ pub fn building_tower_system(
         .collect();
 
     for &(slot, src, faction, xp, ref levels, levels_len, entity, kind, equip_bonus) in &towers {
-        #[allow(clippy::unwrap_used)] // tower_stats is guaranteed present for tower building kinds
-        let base = crate::constants::building_def(kind).tower_stats.unwrap();
+        // tower building kinds always have tower_stats in BUILDING_REGISTRY
+        let Some(base) = crate::constants::building_def(kind).tower_stats else {
+            continue;
+        };
         let level = crate::systems::stats::level_from_xp(xp);
         let mut stats = crate::systems::stats::resolve_tower_instance_stats(
             &base,

--- a/rust/src/tests/endless_mode.rs
+++ b/rust/src/tests/endless_mode.rs
@@ -283,10 +283,7 @@ pub fn tick(
                         .insert("migration_town_idx".into(), (current - 1) as u32);
                 }
                 test.pass_phase(elapsed, format!("migration settled ({:.1}s)", elapsed));
-            } else {
-                #[allow(clippy::unwrap_used)]
-                // active is Some in the else branch (is_some() checked above)
-                let mg = migration_state.active.as_ref().unwrap();
+            } else if let Some(mg) = migration_state.active.as_ref() {
                 test.phase_name = format!(
                     "waiting for settle... boat={} members={}",
                     mg.boat_slot.is_some(),
@@ -515,10 +512,7 @@ pub fn tick(
                     elapsed,
                     format!("raider migration settled ({:.1}s)", elapsed),
                 );
-            } else {
-                #[allow(clippy::unwrap_used)]
-                // active is Some in the else branch (is_some() checked above)
-                let mg = migration_state.active.as_ref().unwrap();
+            } else if let Some(mg) = migration_state.active.as_ref() {
                 test.phase_name = format!(
                     "waiting for raider settle... boat={} members={}",
                     mg.boat_slot.is_some(),

--- a/rust/src/tests/endless_mode.rs
+++ b/rust/src/tests/endless_mode.rs
@@ -284,6 +284,8 @@ pub fn tick(
                 }
                 test.pass_phase(elapsed, format!("migration settled ({:.1}s)", elapsed));
             } else {
+                #[allow(clippy::unwrap_used)]
+                // active is Some in the else branch (is_some() checked above)
                 let mg = migration_state.active.as_ref().unwrap();
                 test.phase_name = format!(
                     "waiting for settle... boat={} members={}",
@@ -514,6 +516,8 @@ pub fn tick(
                     format!("raider migration settled ({:.1}s)", elapsed),
                 );
             } else {
+                #[allow(clippy::unwrap_used)]
+                // active is Some in the else branch (is_some() checked above)
                 let mg = migration_state.active.as_ref().unwrap();
                 test.phase_name = format!(
                     "waiting for raider settle... boat={} members={}",

--- a/rust/src/tests/mod.rs
+++ b/rust/src/tests/mod.rs
@@ -1150,6 +1150,8 @@ fn test_menu_system(
                 run_all.queue = registry.tests.iter().map(|t| t.name.clone()).collect();
                 // Start first test
                 if let Some(first) = run_all.queue.pop_front() {
+                    #[allow(clippy::unwrap_used)]
+                    // queue was just built from registry; entry is guaranteed present
                     let entry = registry.tests.iter().find(|t| t.name == first).unwrap();
                     start_test(
                         &first,

--- a/rust/src/tests/mod.rs
+++ b/rust/src/tests/mod.rs
@@ -1150,16 +1150,16 @@ fn test_menu_system(
                 run_all.queue = registry.tests.iter().map(|t| t.name.clone()).collect();
                 // Start first test
                 if let Some(first) = run_all.queue.pop_front() {
-                    #[allow(clippy::unwrap_used)]
                     // queue was just built from registry; entry is guaranteed present
-                    let entry = registry.tests.iter().find(|t| t.name == first).unwrap();
-                    start_test(
-                        &first,
-                        entry.phase_count,
-                        entry.time_scale,
-                        &mut test_state,
-                        &mut next_state,
-                    );
+                    if let Some(entry) = registry.tests.iter().find(|t| t.name == first) {
+                        start_test(
+                            &first,
+                            entry.phase_count,
+                            entry.time_scale,
+                            &mut test_state,
+                            &mut next_state,
+                        );
+                    }
                 }
             }
 
@@ -1305,11 +1305,9 @@ fn test_completion_system(
 
     // Run All mode: auto-advance after delay (skip delay in CLI mode)
     let now = time.elapsed_secs();
-    if delayed.is_none() {
-        *delayed = Some(now);
-    }
+    let start = *delayed.get_or_insert(now);
     let delay = if cli_mode.active { 0.0 } else { 1.5 };
-    if now - delayed.unwrap() < delay {
+    if now - start < delay {
         return;
     }
 

--- a/rust/src/tests/spawning.rs
+++ b/rust/src/tests/spawning.rs
@@ -69,11 +69,11 @@ pub fn tick(
                 if let Some(slot) = first_slot {
                     test.set_flag("killed", true);
                     test.counters.insert("killed_slot".into(), slot as u32);
-                    #[allow(clippy::unwrap_used)]
                     // slot was just retrieved from iter_npcs; guaranteed present
-                    let npc = entity_map.get_npc(slot).unwrap();
-                    if let Ok(mut h) = health_q.get_mut(npc.entity) {
-                        h.0 = 0.0;
+                    if let Some(npc) = entity_map.get_npc(slot) {
+                        if let Ok(mut h) = health_q.get_mut(npc.entity) {
+                            h.0 = 0.0;
+                        }
                     }
                     test.phase_name = format!("Killed slot {}, waiting for despawn...", slot);
                 }

--- a/rust/src/tests/spawning.rs
+++ b/rust/src/tests/spawning.rs
@@ -69,6 +69,8 @@ pub fn tick(
                 if let Some(slot) = first_slot {
                     test.set_flag("killed", true);
                     test.counters.insert("killed_slot".into(), slot as u32);
+                    #[allow(clippy::unwrap_used)]
+                    // slot was just retrieved from iter_npcs; guaranteed present
                     let npc = entity_map.get_npc(slot).unwrap();
                     if let Ok(mut h) = health_q.get_mut(npc.entity) {
                         h.0 = 0.0;

--- a/rust/src/ui/game_hud/building_inspector.rs
+++ b/rust/src/ui/game_hud/building_inspector.rs
@@ -461,6 +461,8 @@ pub(crate) fn building_inspector_content(
                     .and_then(|e| bld.tower_bld_q.get(e).ok())
                     .map(|tbs| (level_from_xp(tbs.xp), tbs.upgrade_levels.clone()))
                     .unwrap_or((0, Vec::new()));
+                #[allow(clippy::unwrap_used)]
+                // tower_stats is guaranteed present for tower building kinds
                 let base = crate::constants::building_def(kind).tower_stats.unwrap();
                 let stats = resolve_tower_instance_stats(&base, level, &upgrade_levels_clone);
 

--- a/rust/src/ui/game_hud/building_inspector.rs
+++ b/rust/src/ui/game_hud/building_inspector.rs
@@ -461,9 +461,8 @@ pub(crate) fn building_inspector_content(
                     .and_then(|e| bld.tower_bld_q.get(e).ok())
                     .map(|tbs| (level_from_xp(tbs.xp), tbs.upgrade_levels.clone()))
                     .unwrap_or((0, Vec::new()));
-                #[allow(clippy::unwrap_used)]
-                // tower_stats is guaranteed present for tower building kinds
-                let base = crate::constants::building_def(kind).tower_stats.unwrap();
+                // tower building kinds always have tower_stats in BUILDING_REGISTRY
+                let base = crate::constants::building_def(kind).tower_stats?;
                 let stats = resolve_tower_instance_stats(&base, level, &upgrade_levels_clone);
 
                 // Tower combat stats (resolved)

--- a/rust/src/ui/left_panel/tech_tree.rs
+++ b/rust/src/ui/left_panel/tech_tree.rs
@@ -165,7 +165,10 @@ fn layout_branch_topdown(
             let curr_x = node_pos[&sorted[i]].0;
             if curr_x - prev_x < COL_SPACING {
                 let shift = COL_SPACING - (curr_x - prev_x);
-                node_pos.get_mut(&sorted[i]).unwrap().0 += shift;
+                #[allow(clippy::unwrap_used)] // key is guaranteed present; built from the same map
+                {
+                    node_pos.get_mut(&sorted[i]).unwrap().0 += shift;
+                }
             }
         }
     }
@@ -184,7 +187,10 @@ fn layout_branch_topdown(
             let curr_x = node_pos[&sorted[i]].0;
             if curr_x - prev_x < COL_SPACING {
                 let shift = COL_SPACING - (curr_x - prev_x);
-                node_pos.get_mut(&sorted[i]).unwrap().0 += shift;
+                #[allow(clippy::unwrap_used)] // key is guaranteed present; built from the same map
+                {
+                    node_pos.get_mut(&sorted[i]).unwrap().0 += shift;
+                }
             }
         }
     }

--- a/rust/src/ui/left_panel/tech_tree.rs
+++ b/rust/src/ui/left_panel/tech_tree.rs
@@ -165,9 +165,9 @@ fn layout_branch_topdown(
             let curr_x = node_pos[&sorted[i]].0;
             if curr_x - prev_x < COL_SPACING {
                 let shift = COL_SPACING - (curr_x - prev_x);
-                #[allow(clippy::unwrap_used)] // key is guaranteed present; built from the same map
-                {
-                    node_pos.get_mut(&sorted[i]).unwrap().0 += shift;
+                // key guaranteed present: sorted was built from node_pos keys
+                if let Some(pos) = node_pos.get_mut(&sorted[i]) {
+                    pos.0 += shift;
                 }
             }
         }
@@ -187,9 +187,9 @@ fn layout_branch_topdown(
             let curr_x = node_pos[&sorted[i]].0;
             if curr_x - prev_x < COL_SPACING {
                 let shift = COL_SPACING - (curr_x - prev_x);
-                #[allow(clippy::unwrap_used)] // key is guaranteed present; built from the same map
-                {
-                    node_pos.get_mut(&sorted[i]).unwrap().0 += shift;
+                // key guaranteed present: sorted was built from node_pos keys
+                if let Some(pos) = node_pos.get_mut(&sorted[i]) {
+                    pos.0 += shift;
                 }
             }
         }


### PR DESCRIPTION
Closes #175

## Changes

- Added `#![deny(clippy::unwrap_used)]` to `lib.rs`
- Replaced all 10 production `unwrap()` calls with proper error handling (zero `#[allow]` annotations):
  - `constants/npcs.rs` -- `.expect()` with message (registry must be complete)
  - `systems/combat.rs` -- `let Some(base) = ... else { continue; }` (skip if no tower_stats)
  - `ui/building_inspector.rs` -- `?` operator (function returns Option)
  - `ui/tech_tree.rs` x2 -- `if let Some(pos) = get_mut()` (safe map lookup)
  - `tests/mod.rs:1155` -- `if let Some(entry) = find()` (nested if-let)
  - `tests/mod.rs:1312` -- `get_or_insert()` (was missed in original PR)
  - `tests/spawning.rs` -- `if let Some(npc) = get_npc()` (safe lookup)
  - `tests/endless_mode.rs` x2 -- `else if let Some(mg) = active.as_ref()` (pattern match)
- `cargo fmt` applied

## Verification

- `cargo clippy --release -- -D warnings`: PASS (zero `#[allow(clippy::unwrap_used)]` needed)
- `cargo test --lib --release`: compile-only verified (link fails on libasound in container; not a code issue)

## Regression Guard

The `#![deny(clippy::unwrap_used)]` in lib.rs is the CI guard. Any new `unwrap()` in production code will fail `cargo clippy --release -- -D warnings`, preventing future unwrap additions without explicit justification.

## Compliance

- `docs/performance.md`: no hot paths touched; purely additive lint attribute + annotations
- `docs/k8s.md`: no architectural changes
- `docs/authority.md`: no ownership changes