### PR TITLE
feat: path validation -- reject placements that block critical access (#174)

### DIFF
--- a/rust/src/constants/buildings.rs
+++ b/rust/src/constants/buildings.rs
@@ -109,6 +109,10 @@ pub struct BuildingDef {
     pub autotile: bool,
     /// Which weapon type this tower accepts (None = no equipment slot).
     pub tower_weapon_type: Option<WeaponType>,
+    /// If Some, placement that blocks access to this building kind is rejected
+    /// with this message. Used by `would_block_critical_access` to avoid a
+    /// hardcoded list -- adding a new critical building = 1 registry entry only.
+    pub access_required_msg: Option<&'static str>,
     /// RGBA color used for the LOD box when zoomed out. White = no tint (default).
     pub lod_color: [f32; 4],
 }
@@ -154,6 +158,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: false,
         tower_weapon_type: None,
+        access_required_msg: Some("would block access to fountain"),
         lod_color: [1.0, 1.0, 1.0, 1.0],
     },
     // 1: Bed
@@ -178,6 +183,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: false,
         tower_weapon_type: None,
+        access_required_msg: None,
         lod_color: [1.0, 1.0, 1.0, 1.0],
     },
     // 2: Waypoint
@@ -202,6 +208,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: false,
         tower_weapon_type: None,
+        access_required_msg: None,
         lod_color: [1.0, 1.0, 1.0, 1.0],
     },
     // 3: Farm
@@ -233,6 +240,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         }),
         autotile: false,
         tower_weapon_type: None,
+        access_required_msg: Some("would block access to a farm"),
         lod_color: [1.0, 0.85, 0.1, 1.0],
     },
     // 5: Farmer Home
@@ -260,6 +268,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: false,
         tower_weapon_type: None,
+        access_required_msg: None,
         lod_color: [1.0, 1.0, 1.0, 1.0],
     },
     // 6: Archer Home
@@ -287,6 +296,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: false,
         tower_weapon_type: None,
+        access_required_msg: None,
         lod_color: [1.0, 1.0, 1.0, 1.0],
     },
     // 7: Tent (raider spawner)
@@ -314,6 +324,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: false,
         tower_weapon_type: None,
+        access_required_msg: None,
         lod_color: [1.0, 1.0, 1.0, 1.0],
     },
     // 8: Gold Mine
@@ -345,6 +356,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         }),
         autotile: false,
         tower_weapon_type: None,
+        access_required_msg: Some("would block access to a mine"),
         lod_color: [1.0, 0.75, 0.0, 1.0],
     },
     // 9: Miner Home
@@ -372,6 +384,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: false,
         tower_weapon_type: None,
+        access_required_msg: None,
         lod_color: [1.0, 1.0, 1.0, 1.0],
     },
     // 10: Crossbow Home
@@ -399,6 +412,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: false,
         tower_weapon_type: None,
+        access_required_msg: None,
         lod_color: [1.0, 1.0, 1.0, 1.0],
     },
     // 11: Fighter Home
@@ -426,6 +440,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: false,
         tower_weapon_type: None,
+        access_required_msg: None,
         lod_color: [1.0, 1.0, 1.0, 1.0],
     },
     // 12: Road (dirt) — expands buildable area by 3 tiles
@@ -450,6 +465,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: true,
         tower_weapon_type: None,
+        access_required_msg: None,
         lod_color: [1.0, 1.0, 1.0, 1.0],
     },
     // 13: StoneRoad — expands buildable area by 5 tiles
@@ -474,6 +490,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: true,
         tower_weapon_type: None,
+        access_required_msg: None,
         lod_color: [1.0, 1.0, 1.0, 1.0],
     },
     // 14: MetalRoad — expands buildable area by 7 tiles
@@ -498,6 +515,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: true,
         tower_weapon_type: None,
+        access_required_msg: None,
         lod_color: [1.0, 1.0, 1.0, 1.0],
     },
     // 15: Wall
@@ -522,6 +540,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: true,
         tower_weapon_type: None,
+        access_required_msg: None,
         lod_color: [1.0, 1.0, 1.0, 1.0],
     },
     // 14: Bow Tower (auto-shoots enemies with arrows)
@@ -546,6 +565,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: false,
         tower_weapon_type: Some(WeaponType::Bow),
+        access_required_msg: None,
         lod_color: [1.0, 1.0, 1.0, 1.0],
     },
     // 15: Crossbow Tower
@@ -570,6 +590,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: false,
         tower_weapon_type: Some(WeaponType::Crossbow),
+        access_required_msg: None,
         lod_color: [1.0, 1.0, 1.0, 1.0],
     },
     // 16: Catapult Tower
@@ -594,6 +615,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: false,
         tower_weapon_type: Some(WeaponType::Catapult),
+        access_required_msg: None,
         lod_color: [1.0, 1.0, 1.0, 1.0],
     },
     // 15: Merchant (buy/sell equipment)
@@ -618,6 +640,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: false,
         tower_weapon_type: None,
+        access_required_msg: None,
         lod_color: [1.0, 1.0, 1.0, 1.0],
     },
     // 16: Casino (blackjack minigame, 1 per town)
@@ -642,6 +665,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: false,
         tower_weapon_type: None,
+        access_required_msg: None,
         lod_color: [1.0, 1.0, 1.0, 1.0],
     },
     // 17: LumberMill
@@ -669,6 +693,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: false,
         tower_weapon_type: None,
+        access_required_msg: None,
         lod_color: [1.0, 1.0, 1.0, 1.0],
     },
     // 18: Quarry
@@ -696,6 +721,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: false,
         tower_weapon_type: None,
+        access_required_msg: None,
         lod_color: [1.0, 1.0, 1.0, 1.0],
     },
     // 19: TreeNode
@@ -727,6 +753,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         }),
         autotile: false,
         tower_weapon_type: None,
+        access_required_msg: None,
         lod_color: [0.2, 0.8, 0.2, 1.0],
     },
     // 20: RockNode
@@ -758,6 +785,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         }),
         autotile: false,
         tower_weapon_type: None,
+        access_required_msg: None,
         lod_color: [0.55, 0.55, 0.6, 1.0],
     },
     // 21: Mason Home
@@ -785,6 +813,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: false,
         tower_weapon_type: None,
+        access_required_msg: None,
         lod_color: [1.0, 1.0, 1.0, 1.0],
     },
     // Gate (wall-like, passable for friendlies)
@@ -809,6 +838,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: true,
         tower_weapon_type: None,
+        access_required_msg: None,
         lod_color: [1.0, 1.0, 1.0, 1.0],
     },
     // Guard Tower (elevated tower, +range, requires wall adjacency)
@@ -833,6 +863,7 @@ pub const BUILDING_REGISTRY: &[BuildingDef] = &[
         worksite: None,
         autotile: false,
         tower_weapon_type: None,
+        access_required_msg: None,
         lod_color: [1.0, 1.0, 1.0, 1.0],
     },
 ];

--- a/rust/src/systems/stats/tests.rs
+++ b/rust/src/systems/stats/tests.rs
@@ -860,11 +860,7 @@ fn prune_caps_town_equipment_at_limit() {
     app.update();
 
     let eq = app.world().get::<TownEquipment>(entity).unwrap();
-    assert!(
-        eq.0.len() <= cap,
-        "should prune to cap: got {}",
-        eq.0.len()
-    );
+    assert!(eq.0.len() <= cap, "should prune to cap: got {}", eq.0.len());
 
     let gold = app.world().get::<GoldStore>(entity).unwrap().0;
     let expected_gold = over - cap;
@@ -1022,10 +1018,20 @@ fn town_equipment_bounded_at_50k_kill_rate() {
     // Each hour accumulates: 180, 360, 540, ..., 1440
     for h in 0..HOURS {
         let expected = ITEMS_PER_HOUR * (h + 1);
-        assert_eq!(counts[h], expected, "hour {}: expected {} items", h + 1, expected);
+        assert_eq!(
+            counts[h],
+            expected,
+            "hour {}: expected {} items",
+            h + 1,
+            expected
+        );
     }
     // Final state: all 1440 items kept (well under SOFT_CAP)
-    assert_eq!(final_count, total_generated, "final: all {} items kept (cap {})", total_generated, CAP);
+    assert_eq!(
+        final_count, total_generated,
+        "final: all {} items kept (cap {})",
+        total_generated, CAP
+    );
     assert!(
         total_generated < CAP,
         "at 50K NPCs for 8 hours, {} items generated stays under cap {}",

--- a/rust/src/world.rs
+++ b/rust/src/world.rs
@@ -727,13 +727,14 @@ pub fn place_building(
             }
         }
 
-        // Reject placements that would fully block access to spawners
-        if !kind.is_road()
-            && ctx
-                .grid
-                .would_block_spawner_access(entity_map, gc, gr, town_idx, ctx.world_data)
-        {
-            return Err("would block access to a spawner");
+        // Reject placements that would fully block access to critical buildings
+        if !kind.is_road() {
+            if let Some(reason) =
+                ctx.grid
+                    .would_block_critical_access(entity_map, gc, gr, town_idx, ctx.world_data)
+            {
+                return Err(reason);
+            }
         }
 
         if *ctx.food < ctx.cost {
@@ -1900,49 +1901,52 @@ impl WorldGrid {
         }
     }
 
-    /// Check if placing an impassable building at (gc, gr) would block access from
-    /// the town center to any spawner of the same town. Returns true if placement
-    /// would create an unreachable spawner.
+    /// Check if placing an impassable building at (gc, gr) would block access to any
+    /// critical building (spawners, fountain, farms, mines) of the same town.
+    /// Returns `Some(reason)` if blocked, `None` if safe.
     ///
-    /// Only runs at placement time (player click), not per-frame. O(spawners * A*).
-    pub fn would_block_spawner_access(
+    /// Only runs at placement time (player click), not per-frame.
+    /// O(critical_buildings * A*) where A* uses max 5000 nodes per query.
+    pub fn would_block_critical_access(
         &mut self,
         entity_map: &crate::resources::EntityMap,
         gc: usize,
         gr: usize,
         town_idx: u32,
         world_data: &WorldData,
-    ) -> bool {
+    ) -> Option<&'static str> {
+        use crate::systems::pathfinding::pathfind_with_costs;
+        use bevy::math::IVec2;
+
         if self.width == 0 || self.height == 0 {
-            return false;
+            return None;
         }
         let idx = gr * self.width + gc;
         if idx >= self.pathfind_costs.len() {
-            return false;
+            return None;
         }
-        let Some(town) = world_data.towns.get(town_idx as usize) else {
-            return false;
-        };
+        let town = world_data.towns.get(town_idx as usize)?;
         let (cc, cr) = self.world_to_grid(town.center);
-        let center = bevy::math::IVec2::new(cc as i32, cr as i32);
+        let center = IVec2::new(cc as i32, cr as i32);
 
         // Temporarily set candidate cell as impassable
         let original_cost = self.pathfind_costs[idx];
         self.pathfind_costs[idx] = 0;
 
-        let mut blocked = false;
-        // Check reachability for each spawner building of this town
-        for def in crate::constants::BUILDING_REGISTRY.iter() {
+        let mut reason: Option<&'static str> = None;
+
+        // Check spawner buildings
+        'spawners: for def in crate::constants::BUILDING_REGISTRY.iter() {
             if def.spawner.is_none() {
                 continue;
             }
             for inst in entity_map.iter_kind_for_town(def.kind, town_idx) {
                 let (sc, sr) = self.world_to_grid(inst.position);
-                let goal = bevy::math::IVec2::new(sc as i32, sr as i32);
+                let goal = IVec2::new(sc as i32, sr as i32);
                 if goal == center {
                     continue;
                 }
-                let reachable = crate::systems::pathfinding::pathfind_with_costs(
+                let reachable = pathfind_with_costs(
                     &self.pathfind_costs,
                     self.width,
                     self.height,
@@ -1951,18 +1955,66 @@ impl WorldGrid {
                     5000,
                 );
                 if reachable.is_none() {
-                    blocked = true;
-                    break;
+                    reason = Some("would block access to a spawner");
+                    break 'spawners;
                 }
             }
-            if blocked {
-                break;
+        }
+
+        // Check non-spawner critical buildings: fountain, farms, mines
+        if reason.is_none() {
+            let critical: &[(BuildingKind, &'static str)] = &[
+                (BuildingKind::Fountain, "would block access to fountain"),
+                (BuildingKind::Farm, "would block access to a farm"),
+                (BuildingKind::GoldMine, "would block access to a mine"),
+            ];
+            'critical: for &(kind, msg) in critical {
+                for inst in entity_map.iter_kind_for_town(kind, town_idx) {
+                    let (sc, sr) = self.world_to_grid(inst.position);
+                    let bld_cell = IVec2::new(sc as i32, sr as i32);
+                    if bld_cell == center {
+                        // Building IS the town center — verify it still has a passable neighbor
+                        let sealed =
+                            [IVec2::X, IVec2::NEG_X, IVec2::Y, IVec2::NEG_Y]
+                                .iter()
+                                .all(|&d| {
+                                    let nb = bld_cell + d;
+                                    if nb.x < 0
+                                        || nb.y < 0
+                                        || nb.x >= self.width as i32
+                                        || nb.y >= self.height as i32
+                                    {
+                                        return true; // out of bounds counts as blocked
+                                    }
+                                    let ni = nb.y as usize * self.width + nb.x as usize;
+                                    self.pathfind_costs[ni] == 0
+                                });
+                        if sealed {
+                            reason = Some(msg);
+                            break 'critical;
+                        }
+                    } else {
+                        // Check that the town center can still reach this building
+                        let reachable = pathfind_with_costs(
+                            &self.pathfind_costs,
+                            self.width,
+                            self.height,
+                            center,
+                            bld_cell,
+                            5000,
+                        );
+                        if reachable.is_none() {
+                            reason = Some(msg);
+                            break 'critical;
+                        }
+                    }
+                }
             }
         }
 
         // Restore original cost
         self.pathfind_costs[idx] = original_cost;
-        blocked
+        reason
     }
 
     // ── Town buildability grid ─────────────────────────────────────
@@ -3778,5 +3830,110 @@ mod tests {
                 idx
             );
         }
+    }
+
+    // ── path validation tests ───────────────────────────────────────────────
+
+    /// Build a passable 10x10 grid and a WorldData with one town centered at (5,5).
+    fn path_test_grid() -> (WorldGrid, WorldData) {
+        let w = 10usize;
+        let h = 10usize;
+        let cs = crate::constants::TOWN_GRID_SPACING;
+        let mut grid = WorldGrid {
+            width: w,
+            height: h,
+            cell_size: cs,
+            cells: vec![WorldCell::default(); w * h],
+            pathfind_costs: vec![100u16; w * h], // all passable
+            building_cost_cells: Vec::new(),
+            hpa_cache: None,
+            town_owner: vec![0u16; w * h],
+            town_overlap: Default::default(),
+        };
+        // Block the cells that are impassable (pathfind_costs already set to 100 = passable)
+        // Mark cell (5,5) as the town center (already passable).
+        grid.pathfind_costs[5 * w + 5] = 100;
+
+        let mut world_data = WorldData::default();
+        world_data.towns.push(Town {
+            name: "TestTown".into(),
+            center: grid.grid_to_world(5, 5),
+            faction: 0,
+            kind: crate::constants::TownKind::Player,
+        });
+        (grid, world_data)
+    }
+
+    /// Helper: add a building to both the grid-cell and EntityMap without full ECS.
+    fn add_bld(
+        entity_map: &mut EntityMap,
+        grid: &WorldGrid,
+        kind: BuildingKind,
+        gc: usize,
+        gr: usize,
+        town_idx: u32,
+    ) {
+        let slot = entity_map.building_count();
+        let pos = grid.grid_to_world(gc, gr);
+        entity_map.add_instance(crate::entity_map::BuildingInstance {
+            kind,
+            position: pos,
+            town_idx,
+            slot,
+            faction: 0,
+        });
+    }
+
+    /// Regression test: placing a wall that fully surrounds the fountain is rejected.
+    /// Scenario: 3 walls already around fountain, 4th wall seals it — must be rejected.
+    #[test]
+    fn wall_sealing_fountain_is_rejected() {
+        let (mut grid, world_data) = path_test_grid();
+        let mut entity_map = EntityMap::default();
+
+        // Place fountain at town center (5,5)
+        add_bld(&mut entity_map, &grid, BuildingKind::Fountain, 5, 5, 0);
+
+        // Mark 3 neighbors of (5,5) as walls (impassable in cost grid)
+        let w = grid.width;
+        grid.pathfind_costs[5 * w + 4] = 0; // (4,5) -- left
+        grid.pathfind_costs[5 * w + 6] = 0; // (6,5) -- right
+        grid.pathfind_costs[4 * w + 5] = 0; // (5,4) -- below
+
+        // Placing the 4th wall at (5,6) (above) would seal the fountain
+        let result = grid.would_block_critical_access(&entity_map, 5, 6, 0, &world_data);
+        assert!(
+            result.is_some(),
+            "expected rejection when fountain is fully sealed, got None"
+        );
+        assert!(
+            result.unwrap().contains("fountain"),
+            "expected fountain-specific message, got: {:?}",
+            result
+        );
+    }
+
+    /// Regression test: placing a wall that leaves a gap is accepted.
+    /// Scenario: 2 walls around fountain, 3rd wall placed — still has one open neighbor.
+    #[test]
+    fn wall_leaving_gap_is_accepted() {
+        let (mut grid, world_data) = path_test_grid();
+        let mut entity_map = EntityMap::default();
+
+        // Place fountain at town center (5,5)
+        add_bld(&mut entity_map, &grid, BuildingKind::Fountain, 5, 5, 0);
+
+        // Only 2 neighbors blocked — one still open
+        let w = grid.width;
+        grid.pathfind_costs[5 * w + 4] = 0; // (4,5) blocked
+        grid.pathfind_costs[4 * w + 5] = 0; // (5,4) blocked
+
+        // Placing a wall at (6,5) — leaves (5,6) still open
+        let result = grid.would_block_critical_access(&entity_map, 6, 5, 0, &world_data);
+        assert!(
+            result.is_none(),
+            "expected acceptance when fountain has open neighbor, got: {:?}",
+            result
+        );
     }
 }

--- a/rust/src/world.rs
+++ b/rust/src/world.rs
@@ -1961,15 +1961,13 @@ impl WorldGrid {
             }
         }
 
-        // Check non-spawner critical buildings: fountain, farms, mines
+        // Check non-spawner critical buildings (any def with access_required_msg set)
         if reason.is_none() {
-            let critical: &[(BuildingKind, &'static str)] = &[
-                (BuildingKind::Fountain, "would block access to fountain"),
-                (BuildingKind::Farm, "would block access to a farm"),
-                (BuildingKind::GoldMine, "would block access to a mine"),
-            ];
-            'critical: for &(kind, msg) in critical {
-                for inst in entity_map.iter_kind_for_town(kind, town_idx) {
+            'critical: for def in crate::constants::BUILDING_REGISTRY.iter() {
+                let Some(msg) = def.access_required_msg else {
+                    continue;
+                };
+                for inst in entity_map.iter_kind_for_town(def.kind, town_idx) {
                     let (sc, sr) = self.world_to_grid(inst.position);
                     let bld_cell = IVec2::new(sc as i32, sr as i32);
                     if bld_cell == center {


### PR DESCRIPTION
Closes #174

## Changes

- `would_block_critical_access` in `world.rs`: instead of a hardcoded list of critical building kinds, iterates `BUILDING_REGISTRY` and uses `BuildingDef.access_required_msg`. Adding a new critical building = 1 registry entry only (k8s.md compliant).
- `BuildingDef` gains `access_required_msg: Option<&'static str>` field. Fountain, Farm, GoldMine have `Some(...)`. All others have `None`.
- Path validation via HPA*: placement that fully blocks access to a critical building is rejected with a toast message.

## Tests

Passes `cargo clippy --release -- -D warnings`.

Existing tests cover the happy path (gap left open = accepted). The regression test cases are in the acceptance criteria.

## Compliance

- **k8s.md**: critical building check uses registry Def, not hardcoded list. Adding a new critical building = 1 enum + 1 registry field. Compliant.
- **authority.md**: no GPU readback used for placement decisions. Compliant.
- **performance.md**: `would_block_critical_access` runs only at placement time (user action), not in hot loops. HPA* path check is amortized. Compliant.