### PR TITLE
perf: build_building_body_instances dirty tracking -- skip O(68K) rebuild each frame

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -16,6 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
       - name: check skip flag in commit message
         id: msg

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -9,11 +9,29 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  skip-check:
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.msg.outputs.skip }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: check skip flag in commit message
+        id: msg
+        run: |
+          if git log -1 --format=%B | grep -q '\[skip-bench\]'; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
   bench:
+    needs: [skip-check]
     # Skip if PR has 'skip-bench' label or commit message contains [skip-bench]
     if: >
-      !contains(github.event.pull_request.labels.*.name, 'skip-bench') &&
-      !contains(github.event.head_commit.message, '[skip-bench]')
+      needs.skip-check.outputs.skip != 'true' &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-bench')
     runs-on: ubuntu-latest
 
     defaults:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -29,9 +29,7 @@ jobs:
   bench:
     needs: [skip-check]
     # Skip if PR has 'skip-bench' label or commit message contains [skip-bench]
-    if: >
-      needs.skip-check.outputs.skip != 'true' &&
-      !contains(github.event.pull_request.labels.*.name, 'skip-bench')
+    if: needs.skip-check.outputs.skip != 'true' && !contains(github.event.pull_request.labels.*.name, 'skip-bench')
     runs-on: ubuntu-latest
 
     defaults:

--- a/rust/benches/system_bench.rs
+++ b/rust/benches/system_bench.rs
@@ -15,6 +15,9 @@ use endless::constants::*;
 use endless::gpu::populate_gpu_state;
 use endless::gpu::{EntityGpuState, ProjBufferWrites};
 use endless::messages::*;
+use endless::npc_render::{
+    BuildingBodyDirty, BuildingBodyInstances, build_building_body_instances,
+};
 use endless::resources::*;
 use endless::systems::ai_player::{AiSnapshotDirty, RoadStyle};
 use endless::systems::stats;
@@ -1996,8 +1999,88 @@ criterion_group!(
     bench_sync_pathfind_costs_system,
     bench_farm_visual_system,
     bench_sync_sleeping_system,
+    bench_build_building_body_instances,
 );
 criterion_main!(benches);
+
+fn bench_build_building_body_instances(c: &mut Criterion) {
+    let mut group = c.benchmark_group("build_building_body_instances");
+    group.sample_size(20);
+    const INSTANCE_COUNT: usize = 68_000;
+
+    let setup_app = || {
+        let mut app = build_bench_app();
+        app.insert_resource(BuildingBodyInstances::default());
+        app.insert_resource(BuildingBodyDirty::default());
+
+        let world = app.world_mut();
+        let mut slots = Vec::with_capacity(INSTANCE_COUNT);
+        {
+            let mut pool = world.resource_mut::<GpuSlotPool>();
+            for _ in 0..INSTANCE_COUNT {
+                if let Some(slot) = pool.alloc_reset() {
+                    slots.push(slot);
+                }
+            }
+        }
+        {
+            let mut em = world.resource_mut::<EntityMap>();
+            for (i, &slot) in slots.iter().enumerate() {
+                let x = 400.0 + (i % 260) as f32 * 32.0;
+                let y = 400.0 + (i / 260) as f32 * 32.0;
+                em.add_instance(BuildingInstance {
+                    kind: world::BuildingKind::TreeNode,
+                    position: Vec2::new(x, y),
+                    town_idx: 0,
+                    slot,
+                    faction: 0,
+                });
+            }
+        }
+        {
+            let mut gpu = world.resource_mut::<EntityGpuState>();
+            for &slot in &slots {
+                gpu.positions[slot * 2] = 400.0 + (slot % 260) as f32 * 32.0;
+                gpu.positions[slot * 2 + 1] = 400.0 + (slot / 260) as f32 * 32.0;
+                gpu.sprite_indices[slot * 4] = 1.0;
+                gpu.sprite_indices[slot * 4 + 1] = 0.0;
+                gpu.sprite_indices[slot * 4 + 2] = 1.0;
+                gpu.healths[slot] = 1.0;
+            }
+        }
+        app
+    };
+
+    group.bench_with_input(
+        BenchmarkId::new("dirty", INSTANCE_COUNT),
+        &INSTANCE_COUNT,
+        |b, _| {
+            let mut app = setup_app();
+            b.iter(|| {
+                app.world_mut().resource_mut::<BuildingBodyDirty>().dirty = true;
+                let _ = app
+                    .world_mut()
+                    .run_system_once(build_building_body_instances);
+            });
+        },
+    );
+
+    group.bench_with_input(
+        BenchmarkId::new("clean", INSTANCE_COUNT),
+        &INSTANCE_COUNT,
+        |b, _| {
+            let mut app = setup_app();
+            app.world_mut().resource_mut::<BuildingBodyDirty>().dirty = false;
+            b.iter(|| {
+                let _ = app
+                    .world_mut()
+                    .run_system_once(build_building_body_instances);
+            });
+        },
+    );
+
+    group.finish();
+}
 
 // ── sync_sleeping_system benchmark (issue-188, event-driven) ──────
 

--- a/rust/src/npc_render.rs
+++ b/rust/src/npc_render.rs
@@ -737,7 +737,7 @@ fn mark_building_body_dirty(
 
 /// Build building body instances from EntityGpuState for instance-buffer rendering.
 /// Skips rebuild when BuildingBodyDirty is false (nothing changed since last frame).
-fn build_building_body_instances(
+pub fn build_building_body_instances(
     gpu_state: Res<crate::gpu::EntityGpuState>,
     entity_map: Res<crate::resources::EntityMap>,
     mut instances: ResMut<BuildingBodyInstances>,

--- a/rust/src/npc_render.rs
+++ b/rust/src/npc_render.rs
@@ -182,6 +182,28 @@ pub struct NpcVisualBuffers {
 #[derive(Resource, Default)]
 pub struct BuildingBodyInstances(pub Vec<InstanceData>);
 
+/// Dirty flag for BuildingBodyInstances. Set by mark_building_body_dirty, cleared after rebuild.
+/// Avoids O(68K) rebuild every frame when nothing visual has changed for buildings.
+#[derive(Resource)]
+pub struct BuildingBodyDirty {
+    /// Rebuild needed this frame.
+    pub dirty: bool,
+    /// Any building slot had active flash last frame (need one extra rebuild to clear flash=0).
+    pub had_building_flash: bool,
+    /// Building count at last rebuild (detects placements/removals).
+    pub last_building_count: usize,
+}
+
+impl Default for BuildingBodyDirty {
+    fn default() -> Self {
+        Self {
+            dirty: true, // start dirty so first frame always builds
+            had_building_flash: false,
+            last_building_count: usize::MAX, // force rebuild on first frame
+        }
+    }
+}
+
 /// Any system that needs to render building/farm/mine overlays pushes InstanceData here.
 #[derive(Resource, Default)]
 pub struct OverlayInstances(pub Vec<InstanceData>);
@@ -565,6 +587,7 @@ impl Plugin for NpcRenderPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<OverlayInstances>()
             .init_resource::<BuildingBodyInstances>()
+            .init_resource::<BuildingBodyDirty>()
             .init_resource::<SelectionOverlayInstances>()
             .init_resource::<crate::resources::DirectControlSet>()
             .add_systems(Startup, (spawn_npc_batch, spawn_proj_batch))
@@ -572,7 +595,8 @@ impl Plugin for NpcRenderPlugin {
                 PostUpdate,
                 (
                     sync_direct_control_set,
-                    build_building_body_instances,
+                    mark_building_body_dirty.after(crate::gpu::populate_gpu_state),
+                    build_building_body_instances.after(mark_building_body_dirty),
                     build_overlay_instances,
                     build_selection_overlay.after(sync_direct_control_set),
                 ),
@@ -675,14 +699,55 @@ fn extract_camera_state(
 // OVERLAY INSTANCES (main world → render world, zero-clone)
 // =============================================================================
 
+/// Mark BuildingBodyInstances dirty when any building visual state may have changed.
+/// Runs in PostUpdate after populate_gpu_state so flash_only_indices is current.
+fn mark_building_body_dirty(
+    mut dirty: ResMut<BuildingBodyDirty>,
+    construction_changed: Query<(), Changed<crate::components::ConstructionProgress>>,
+    entity_map: Res<crate::resources::EntityMap>,
+    gpu_state: Res<crate::gpu::EntityGpuState>,
+) {
+    // Building placed or removed: count changed.
+    let count = entity_map.building_count();
+    if count != dirty.last_building_count {
+        dirty.last_building_count = count;
+        dirty.dirty = true;
+        dirty.had_building_flash = false;
+        return;
+    }
+    // Any building under construction ticked (ConstructionProgress changed).
+    if !construction_changed.is_empty() {
+        dirty.dirty = true;
+        return;
+    }
+    // Any building slot has active damage flash (check flash_only_indices, not all 68K slots).
+    let mut has_building_flash = false;
+    for &slot in &gpu_state.flash_only_indices {
+        if entity_map.get_instance(slot).is_some() {
+            has_building_flash = true;
+            break;
+        }
+    }
+    // Dirty if flash active now OR was active last frame (one extra rebuild to clear flash=0).
+    if has_building_flash || dirty.had_building_flash {
+        dirty.dirty = true;
+    }
+    dirty.had_building_flash = has_building_flash;
+}
+
 /// Build building body instances from EntityGpuState for instance-buffer rendering.
-/// Buildings are few (<500), so rebuilding each frame is cheap.
+/// Skips rebuild when BuildingBodyDirty is false (nothing changed since last frame).
 fn build_building_body_instances(
     gpu_state: Res<crate::gpu::EntityGpuState>,
     entity_map: Res<crate::resources::EntityMap>,
     mut instances: ResMut<BuildingBodyInstances>,
+    mut dirty: ResMut<BuildingBodyDirty>,
     construction_q: Query<&crate::components::ConstructionProgress>,
 ) {
+    if !dirty.dirty {
+        return;
+    }
+    dirty.dirty = false;
     instances.0.clear();
     for inst in entity_map.iter_instances() {
         let idx = inst.slot;
@@ -1098,6 +1163,94 @@ mod tests {
             sentinel_equip_len * std::mem::size_of::<f32>(),
             equip_bytes,
             "sentinel_equip length must match equip buffer byte size"
+        );
+    }
+
+    /// Regression test for issue #187: build_building_body_instances must skip rebuild when dirty=false.
+    /// If the guard is removed, the system would clear instances every frame regardless of dirty flag.
+    #[test]
+    fn building_body_instances_skips_rebuild_when_not_dirty() {
+        let mut app = App::new();
+
+        // Pre-populate instances with a sentinel value.
+        let mut instances = BuildingBodyInstances::default();
+        instances.0.push(InstanceData {
+            position: [1.0, 2.0],
+            sprite: [3.0, 4.0],
+            color: [1.0, 1.0, 1.0, 1.0],
+            health: 1.0,
+            flash: 0.0,
+            scale: 64.0,
+            atlas_id: 1.0,
+            rotation: 0.0,
+        });
+
+        app.insert_resource(instances)
+            .insert_resource(BuildingBodyDirty {
+                dirty: false,
+                had_building_flash: false,
+                last_building_count: 0,
+            })
+            .insert_resource(crate::resources::EntityMap::default())
+            .insert_resource(crate::gpu::EntityGpuState::default())
+            .add_systems(Update, build_building_body_instances);
+
+        app.update();
+
+        let result = app.world().resource::<BuildingBodyInstances>();
+        assert_eq!(
+            result.0.len(),
+            1,
+            "build_building_body_instances must not clear instances when dirty=false"
+        );
+    }
+
+    /// Regression test for issue #187: mark_building_body_dirty must set dirty=true when building count changes.
+    /// If the count check is removed, newly placed buildings would not trigger a rebuild.
+    #[test]
+    fn building_body_dirty_triggers_on_building_count_change() {
+        use crate::entity_map::BuildingInstance;
+        use crate::world::BuildingKind;
+
+        let mut app = App::new();
+
+        app.insert_resource(BuildingBodyDirty {
+            dirty: false,
+            had_building_flash: false,
+            last_building_count: 0,
+        })
+        .insert_resource(crate::resources::EntityMap::default())
+        .insert_resource(crate::gpu::EntityGpuState::default())
+        .add_systems(Update, mark_building_body_dirty);
+
+        // First update: no buildings -> count stays 0 -> dirty stays false.
+        app.update();
+        assert!(
+            !app.world().resource::<BuildingBodyDirty>().dirty,
+            "dirty should remain false when no buildings exist"
+        );
+
+        // Add a building to EntityMap to simulate a placement.
+        app.world_mut()
+            .resource_mut::<crate::resources::EntityMap>()
+            .add_instance(BuildingInstance {
+                kind: BuildingKind::Farm,
+                position: bevy::math::Vec2::new(64.0, 64.0),
+                town_idx: 1,
+                slot: 100,
+                faction: 1,
+            });
+
+        // Second update: count is now 1, last_building_count was 0 -> dirty=true.
+        app.update();
+        let dirty = app.world().resource::<BuildingBodyDirty>();
+        assert!(
+            dirty.dirty,
+            "mark_building_body_dirty must set dirty=true when building count changes"
+        );
+        assert_eq!(
+            dirty.last_building_count, 1,
+            "last_building_count must be updated to new count"
         );
     }
 }


### PR DESCRIPTION
## Summary

Adds dirty tracking to `build_building_body_instances` so the O(68K) instance rebuild is skipped when no building visual state changed.

**Root cause**: The system unconditionally called `instances.0.clear()` then rebuilt all 68,723 instances every frame, even when nothing changed. 95% are trees/rocks that never change state.

**Fix**: Two new additions:
- `BuildingBodyDirty` resource tracking dirty state, last-frame flash presence, and last building count
- `mark_building_body_dirty` system (PostUpdate, after `populate_gpu_state`) that sets dirty=true on:
  - Building count change (placement/removal)
  - Any `Changed<ConstructionProgress>` (construction ticking)
  - Any building slot with active damage flash (via `flash_only_indices`, O(active_flash) not O(68K))
  - One extra frame after flash clears (to render flash=0)

Expected result: idle-frame avg drops from 1.5-1.9ms to ~0ms. During active building placement or damage, the rebuild still runs but only when needed.

## Test plan
- [ ] Regression: `building_body_instances_skips_rebuild_when_not_dirty` -- instances not cleared when dirty=false
- [ ] Regression: `building_body_dirty_triggers_on_building_count_change` -- dirty=true after adding building to EntityMap
- [ ] BRP profiling: `endless-cli get_perf` shows `build_building_body_instances` < 0.3ms at 68K idle
- [ ] Visual verify: buildings still render (construction progress, damage flash, faction tint) during active gameplay

Fixes #187

Generated with [Claude Code](https://claude.com/claude-code)