### PR TITLE
perf: replace polling farm_visual_system with message-driven events

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -177,7 +177,7 @@ All volatile numeric constants in one place. Policy sections above describe *why
 | `ENERGY_WAKE_THRESHOLD` | 90.0 | `constants.rs:1210` |
 | Faction readback throttle | 60 frames | `gpu.rs` |
 | Threat readback throttle | 30 frames | `gpu.rs` |
-| Farm visual cadence | every 4th frame | `behavior.rs` |
+| Farm visual cadence | event-driven (FarmReadyMsg/FarmHarvestedMsg) | `economy/mod.rs` |
 | ProfilerCache refresh | 15 frames, top 10 | `ui/game_hud.rs` |
 | Healing enter-check cadence | 1/4 NPCs per frame | `health.rs` |
 | Gap coalescing waste budget | ~24KB total across all buffers | `gpu.rs` |

--- a/rust/benches/system_bench.rs
+++ b/rust/benches/system_bench.rs
@@ -22,9 +22,9 @@ use endless::systems::{
     AiKind, AiPersonality, AiPlayer, AiPlayerConfig, AiPlayerState, advance_waypoints_system,
     ai_decision_system, arrival_system, attack_system, building_tower_system,
     construction_tick_system, cooldown_system, damage_system, death_system, decision_system,
-    energy_system, gpu_position_readback, growth_system, healing_system, npc_regen_system,
-    on_duty_tick_system, process_proj_hits, resolve_movement_system, spawn_npc_system,
-    spawner_respawn_system,
+    energy_system, farm_visual_system, gpu_position_readback, growth_system, healing_system,
+    npc_regen_system, on_duty_tick_system, process_proj_hits, resolve_movement_system,
+    spawn_npc_system, spawner_respawn_system,
 };
 use endless::world;
 
@@ -1874,6 +1874,99 @@ fn bench_sync_pathfind_costs_system(c: &mut Criterion) {
     group.finish();
 }
 
+/// Benchmark farm_visual_system: event-driven marker spawn/despawn.
+/// Tests steady-state (no events), post-load (Added), and harvest (FarmHarvestedMsg).
+fn bench_farm_visual_system(c: &mut Criterion) {
+    let mut group = c.benchmark_group("farm_visual_system");
+    group.sample_size(20);
+    const BUILDING_COUNTS: &[usize] = &[1_000, 5_000];
+    for &bcount in BUILDING_COUNTS {
+        // Steady state: no events, all queries empty
+        group.bench_with_input(
+            BenchmarkId::new("steady_state", bcount),
+            &bcount,
+            |b, &bcount| {
+                let mut app = build_bench_app();
+                app.add_message::<FarmReadyMsg>();
+                app.add_message::<FarmHarvestedMsg>();
+                spawn_bench_town(&mut app);
+                populate_npcs(&mut app, 100);
+                populate_growable_buildings(&mut app, bcount);
+                // Warmup: first run processes Added<ProductionState>
+                let _ = app.world_mut().run_system_once(farm_visual_system);
+                b.iter(|| {
+                    let _ = app.world_mut().run_system_once(farm_visual_system);
+                });
+            },
+        );
+
+        // Burst ready: growth_system fires FarmReadyMsg for 25% of buildings
+        group.bench_with_input(
+            BenchmarkId::new("burst_ready", bcount),
+            &bcount,
+            |b, &bcount| {
+                let mut app = build_bench_app();
+                app.add_message::<FarmReadyMsg>();
+                app.add_message::<FarmHarvestedMsg>();
+                spawn_bench_town(&mut app);
+                populate_npcs(&mut app, 100);
+                populate_growable_buildings(&mut app, bcount);
+                let _ = app.world_mut().run_system_once(farm_visual_system);
+                let msg_count = bcount / 4;
+                b.iter(|| {
+                    let _ = app.world_mut().run_system_once(
+                        move |mut writer: MessageWriter<FarmReadyMsg>,
+                              q: Query<&GpuSlot, With<Building>>| {
+                            for slot in q.iter().take(msg_count) {
+                                writer.write(FarmReadyMsg { slot: slot.0 });
+                            }
+                        },
+                    );
+                    let _ = app.world_mut().run_system_once(farm_visual_system);
+                });
+            },
+        );
+
+        // Burst harvest: FarmHarvestedMsg for 25% of buildings
+        group.bench_with_input(
+            BenchmarkId::new("burst_harvest", bcount),
+            &bcount,
+            |b, &bcount| {
+                let mut app = build_bench_app();
+                app.add_message::<FarmReadyMsg>();
+                app.add_message::<FarmHarvestedMsg>();
+                spawn_bench_town(&mut app);
+                populate_npcs(&mut app, 100);
+                populate_growable_buildings(&mut app, bcount);
+                let _ = app.world_mut().run_system_once(farm_visual_system);
+                let msg_count = bcount / 4;
+                b.iter(|| {
+                    // First make them ready, then harvest
+                    let _ = app.world_mut().run_system_once(
+                        move |mut writer: MessageWriter<FarmReadyMsg>,
+                              q: Query<&GpuSlot, With<Building>>| {
+                            for slot in q.iter().take(msg_count) {
+                                writer.write(FarmReadyMsg { slot: slot.0 });
+                            }
+                        },
+                    );
+                    let _ = app.world_mut().run_system_once(farm_visual_system);
+                    let _ = app.world_mut().run_system_once(
+                        move |mut writer: MessageWriter<FarmHarvestedMsg>,
+                              q: Query<&GpuSlot, With<Building>>| {
+                            for slot in q.iter().take(msg_count) {
+                                writer.write(FarmHarvestedMsg { slot: slot.0 });
+                            }
+                        },
+                    );
+                    let _ = app.world_mut().run_system_once(farm_visual_system);
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_decision_system,
@@ -1901,5 +1994,6 @@ criterion_group!(
     bench_ai_decision_system,
     bench_rebuild_building_grid_system,
     bench_sync_pathfind_costs_system,
+    bench_farm_visual_system,
 );
 criterion_main!(benches);

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -36,9 +36,10 @@ use bevy::prelude::*;
 use bevy::remote::{RemotePlugin, http::RemoteHttpPlugin};
 
 use messages::{
-    BuildingGridDirtyMsg, CombatLogMsg, DamageMsg, DestroyBuildingMsg, GpuUpdateMsg,
-    HealingZonesDirtyMsg, MiningDirtyMsg, PatrolPerimeterDirtyMsg, PatrolSwapMsg, PatrolsDirtyMsg,
-    ProjGpuUpdateMsg, SelectFactionMsg, SpawnNpcMsg, SquadsDirtyMsg, TerrainDirtyMsg,
+    BuildingGridDirtyMsg, CombatLogMsg, DamageMsg, DestroyBuildingMsg, FarmHarvestedMsg,
+    FarmReadyMsg, GpuUpdateMsg, HealingZonesDirtyMsg, MiningDirtyMsg, PatrolPerimeterDirtyMsg,
+    PatrolSwapMsg, PatrolsDirtyMsg, ProjGpuUpdateMsg, SelectFactionMsg, SpawnNpcMsg,
+    SquadsDirtyMsg, TerrainDirtyMsg,
 };
 use resources::{
     ActiveHealingSlots, AutoUpgrade, BuildMenuContext, BuildingHealState, CombatDebug, CombatLog,
@@ -323,6 +324,8 @@ pub fn build_app(app: &mut App) {
         .add_message::<ProjGpuUpdateMsg>()
         .add_message::<CombatLogMsg>()
         .add_message::<messages::WorkIntentMsg>()
+        .add_message::<FarmReadyMsg>()
+        .add_message::<FarmHarvestedMsg>()
         .add_message::<BuildingGridDirtyMsg>()
         .add_message::<TerrainDirtyMsg>()
         .add_message::<PatrolsDirtyMsg>()

--- a/rust/src/messages.rs
+++ b/rust/src/messages.rs
@@ -63,6 +63,24 @@ pub struct CombatLogMsg {
 }
 
 // ============================================================================
+// FARM VISUAL MESSAGES
+// ============================================================================
+
+/// A production building (farm, mine, tree node) transitioned from not-ready to ready.
+/// Emitted by growth_system. Consumed by farm_visual_system to spawn FarmReadyMarker.
+#[derive(Message, Clone)]
+pub struct FarmReadyMsg {
+    pub slot: usize,
+}
+
+/// A production building was harvested (take_yield returned > 0), transitioning ready -> not ready.
+/// Emitted by decision_system. Consumed by farm_visual_system to despawn FarmReadyMarker.
+#[derive(Message, Clone)]
+pub struct FarmHarvestedMsg {
+    pub slot: usize,
+}
+
+// ============================================================================
 // DIRTY-FLAG MESSAGES (replace DirtyFlags resource)
 // ============================================================================
 

--- a/rust/src/systems/decision/mod.rs
+++ b/rust/src/systems/decision/mod.rs
@@ -65,6 +65,7 @@ pub struct DecisionExtras<'w> {
     pub gpu_updates: MessageWriter<'w, GpuUpdateMsg>,
     pub work_intents: MessageWriter<'w, WorkIntentMsg>,
     pub damage: MessageWriter<'w, DamageMsg>,
+    pub farm_visual: MessageWriter<'w, crate::messages::FarmHarvestedMsg>,
     pub squad_state: Res<'w, SquadState>,
     pub selected_npc: Res<'w, SelectedNpc>,
     pub settings: Res<'w, UserSettings>,
@@ -327,6 +328,7 @@ pub fn decision_system(
 
     let npc_logs = &mut extras.npc_logs;
     let combat_log = &mut extras.combat_log;
+    let farm_visual = &mut extras.farm_visual;
     let squad_state = &extras.squad_state;
     let frame = DECISION_FRAME.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let positions = &gpu_state.positions;
@@ -732,6 +734,9 @@ pub fn decision_system(
                                         });
                                     if let Some((food, log_msg)) = harvest {
                                         // Harvest — release worksite, carry home
+                                        farm_visual.write(crate::messages::FarmHarvestedMsg {
+                                            slot: farm_slot,
+                                        });
                                         let uid = worksite
                                             .and_then(|s| entity_map.entities.get(&s).copied());
                                         extras.work_intents.write(WorkIntentMsg(
@@ -908,8 +913,8 @@ pub fn decision_system(
                             });
 
                             if let Some(fp) = ready_farm_pos {
-                                let farm_e = entity_map
-                                    .slot_at_position(fp)
+                                let raided_slot = entity_map.slot_at_position(fp);
+                                let farm_e = raided_slot
                                     .and_then(|slot| entity_map.entities.get(&slot).copied());
                                 let food = farm_e
                                     .and_then(|e| production_q.get_mut(e).ok())
@@ -936,6 +941,12 @@ pub fn decision_system(
                                         f
                                     })
                                     .unwrap_or(0);
+                                if food > 0 {
+                                    if let Some(slot) = raided_slot {
+                                        farm_visual
+                                            .write(crate::messages::FarmHarvestedMsg { slot });
+                                    }
+                                }
 
                                 carried_loot.food += food.max(1);
                                 transition_activity(
@@ -1065,6 +1076,10 @@ pub fn decision_system(
                                     })
                                     .unwrap_or(0);
                                 if base_gold > 0 {
+                                    if let Some(slot) = mine_slot {
+                                        farm_visual
+                                            .write(crate::messages::FarmHarvestedMsg { slot });
+                                    }
                                     combat_log.write(CombatLogMsg {
                                         kind: CombatEventKind::Harvest,
                                         faction: faction_i32,
@@ -2088,6 +2103,7 @@ pub fn decision_system(
                             .map_or(FarmMode::Crops, |m| m.0);
                         let base_yield = ps.take_yield(kind, mode);
                         if base_yield > 0 {
+                            farm_visual.write(crate::messages::FarmHarvestedMsg { slot });
                             combat_log.write(CombatLogMsg {
                                 kind: CombatEventKind::Harvest,
                                 faction: faction_i32,

--- a/rust/src/systems/decision/tests.rs
+++ b/rust/src/systems/decision/tests.rs
@@ -21,6 +21,7 @@ fn setup_decision_app(policy: PolicySet) -> App {
     app.add_message::<crate::messages::DamageMsg>();
     app.add_message::<GpuUpdateMsg>();
     app.add_message::<WorkIntentMsg>();
+    app.add_message::<crate::messages::FarmHarvestedMsg>();
     app.insert_resource(WorldData {
         towns: vec![Town {
             name: "TestTown".into(),

--- a/rust/src/systems/economy/mod.rs
+++ b/rust/src/systems/economy/mod.rs
@@ -13,7 +13,9 @@ use crate::constants::{
     RAIDER_SETTLE_RADIUS, SPAWNER_RESPAWN_HOURS, STARVING_HP_CAP, STARVING_SPEED_MULT,
     TOWN_GRID_SPACING,
 };
-use crate::messages::{CombatLogMsg, GpuUpdate, GpuUpdateMsg, SpawnNpcMsg};
+use crate::messages::{
+    CombatLogMsg, FarmHarvestedMsg, FarmReadyMsg, GpuUpdate, GpuUpdateMsg, SpawnNpcMsg,
+};
 use crate::resources::*;
 use crate::systemparams::{EconomyState, GameLog, WorldState};
 use crate::systems::ai_player::{AiKind, AiPersonality, AiPlayer, AiPlayerState};
@@ -148,6 +150,7 @@ pub fn growth_system(
     game_time: Res<GameTime>,
     entity_map: Res<EntityMap>,
     mut town_access: crate::systemparams::TownAccess,
+    mut farm_ready: MessageWriter<crate::messages::FarmReadyMsg>,
     mut production_q: Query<
         (
             &GpuSlot,
@@ -220,6 +223,7 @@ pub fn growth_system(
                             if production.progress >= 1.0 {
                                 production.ready = true;
                                 production.progress = 1.0;
+                                farm_ready.write(FarmReadyMsg { slot });
                             }
                         }
                     }
@@ -238,6 +242,7 @@ pub fn growth_system(
                             if production.progress >= 1.0 {
                                 production.ready = true;
                                 production.progress = 1.0;
+                                farm_ready.write(FarmReadyMsg { slot });
                             }
                         }
                     }
@@ -256,6 +261,7 @@ pub fn growth_system(
                     if production.progress >= 1.0 {
                         production.ready = true;
                         production.progress = 1.0;
+                        farm_ready.write(FarmReadyMsg { slot });
                     }
                 }
             }
@@ -267,6 +273,7 @@ pub fn growth_system(
                     if production.progress >= 1.0 {
                         production.ready = true;
                         production.progress = 1.0;
+                        farm_ready.write(FarmReadyMsg { slot });
                     }
                 }
             }
@@ -277,6 +284,7 @@ pub fn growth_system(
                     if production.progress >= 1.0 {
                         production.ready = true;
                         production.progress = 1.0;
+                        farm_ready.write(FarmReadyMsg { slot });
                     }
                 }
             }
@@ -450,45 +458,63 @@ pub fn starvation_system(
 // FARM VISUAL SYSTEM
 // ============================================================================
 
-/// Spawns/despawns FarmReadyMarker entities when farm state transitions.
-/// Growing->Ready: spawn marker. Ready->Growing (harvest): despawn marker.
-/// Uses a slot->marker-entity map for O(1) despawn instead of scanning all markers.
-/// Compacts stale entries for removed farms so slot reuse stays correct.
+/// Spawns/despawns FarmReadyMarker entities when farm production state transitions.
+///
+/// Event-driven: runs every frame but does near-zero work at steady state.
+/// - Added<ProductionState>: initializes markers for newly spawned/loaded farms.
+/// - FarmReadyMsg: spawns a marker when growth_system signals ready.
+/// - FarmHarvestedMsg: despawns a marker when decision_system signals harvest.
+/// - RemovedComponents<ProductionState>: cleans up markers for despawned buildings.
 pub fn farm_visual_system(
     mut commands: Commands,
-    farms_q: Query<(&GpuSlot, &ProductionState), With<Building>>,
+    added_q: Query<(Entity, &GpuSlot, &ProductionState), (With<Building>, Added<ProductionState>)>,
+    mut removed: RemovedComponents<ProductionState>,
+    mut ready_msgs: MessageReader<FarmReadyMsg>,
+    mut harvested_msgs: MessageReader<FarmHarvestedMsg>,
     markers: Query<(), With<FarmReadyMarker>>,
     mut marker_map: Local<HashMap<usize, Entity>>,
-    mut frame_count: Local<u32>,
+    mut entity_to_slot: Local<HashMap<Entity, usize>>,
 ) {
-    // Cadence: only check every 4th frame (crop state changes slowly)
-    *frame_count = frame_count.wrapping_add(1);
-    if !(*frame_count).is_multiple_of(4) {
-        return;
-    }
-
-    let mut previous_markers = std::mem::take(&mut *marker_map);
-    for (gpu_slot, production) in &farms_q {
+    // Initialize markers for newly spawned production buildings (handles post-load restore).
+    for (farm_entity, gpu_slot, production) in &added_q {
         let slot = gpu_slot.0;
-        let live_marker = previous_markers
-            .remove(&slot)
-            .filter(|entity| markers.get(*entity).is_ok());
-
+        entity_to_slot.insert(farm_entity, slot);
         if production.ready {
-            if let Some(marker_entity) = live_marker {
-                marker_map.insert(slot, marker_entity);
-            } else {
-                let marker_entity = commands.spawn(FarmReadyMarker { farm_slot: slot }).id();
-                marker_map.insert(slot, marker_entity);
-            }
-        } else if let Some(marker_entity) = live_marker {
-            commands.entity(marker_entity).despawn();
+            let marker = commands.spawn(FarmReadyMarker { farm_slot: slot }).id();
+            marker_map.insert(slot, marker);
         }
     }
 
-    for marker_entity in previous_markers.into_values() {
-        if markers.get(marker_entity).is_ok() {
-            commands.entity(marker_entity).despawn();
+    // Clean up markers for despawned production buildings.
+    for farm_entity in removed.read() {
+        if let Some(slot) = entity_to_slot.remove(&farm_entity) {
+            if let Some(marker) = marker_map.remove(&slot) {
+                if markers.get(marker).is_ok() {
+                    commands.entity(marker).despawn();
+                }
+            }
+        }
+    }
+
+    // Spawn marker when growth_system signals a farm became ready.
+    for msg in ready_msgs.read() {
+        let slot = msg.slot;
+        let live = marker_map
+            .get(&slot)
+            .is_some_and(|&e| markers.get(e).is_ok());
+        if !live {
+            let marker = commands.spawn(FarmReadyMarker { farm_slot: slot }).id();
+            marker_map.insert(slot, marker);
+        }
+    }
+
+    // Despawn marker when decision_system signals a farm was harvested.
+    for msg in harvested_msgs.read() {
+        let slot = msg.slot;
+        if let Some(marker) = marker_map.remove(&slot) {
+            if markers.get(marker).is_ok() {
+                commands.entity(marker).despawn();
+            }
         }
     }
 }

--- a/rust/src/systems/economy/tests.rs
+++ b/rust/src/systems/economy/tests.rs
@@ -5,6 +5,7 @@ use crate::components::{
 };
 use crate::messages::GpuUpdateMsg;
 use crate::resources::GameTime;
+use bevy::ecs::system::RunSystemOnce;
 use bevy::time::TimeUpdateStrategy;
 
 fn test_cached_stats() -> CachedStats {
@@ -642,6 +643,7 @@ fn setup_growth_app() -> App {
     app.insert_resource(TimeUpdateStrategy::ManualDuration(
         std::time::Duration::from_secs_f32(1.0),
     ));
+    app.add_message::<crate::messages::FarmReadyMsg>();
     app.add_systems(FixedUpdate, growth_system);
     app.update();
     app.update();
@@ -1251,6 +1253,8 @@ fn setup_farm_visual_app() -> App {
     app.insert_resource(TimeUpdateStrategy::ManualDuration(
         std::time::Duration::from_secs_f32(1.0),
     ));
+    app.add_message::<crate::messages::FarmReadyMsg>();
+    app.add_message::<crate::messages::FarmHarvestedMsg>();
     app.add_systems(FixedUpdate, farm_visual_system);
     app.update();
     app.update();
@@ -1296,10 +1300,8 @@ fn find_farm_marker(app: &mut App, slot: usize) -> Option<Entity> {
 fn farm_visual_spawns_marker_when_ready() {
     let mut app = setup_farm_visual_app();
     add_farm_visual(&mut app, 5000, true);
-    // Run 4 updates to hit the frame_count % 4 == 0 cadence
-    for _ in 0..4 {
-        app.update();
-    }
+    // One update: Added<ProductionState> fires and marker is spawned immediately
+    app.update();
     let count = count_farm_markers(&mut app);
     assert!(
         count > 0,
@@ -1311,9 +1313,7 @@ fn farm_visual_spawns_marker_when_ready() {
 fn farm_visual_no_marker_when_not_ready() {
     let mut app = setup_farm_visual_app();
     add_farm_visual(&mut app, 5000, false);
-    for _ in 0..4 {
-        app.update();
-    }
+    app.update();
     let count = count_farm_markers(&mut app);
     assert_eq!(count, 0, "should not spawn marker when growth_ready=false");
 }
@@ -1321,27 +1321,25 @@ fn farm_visual_no_marker_when_not_ready() {
 #[test]
 fn farm_visual_despawns_marker_when_no_longer_ready() {
     let mut app = setup_farm_visual_app();
-    let entity = add_farm_visual(&mut app, 5000, true);
-    // Spawn the marker
-    for _ in 0..4 {
-        app.update();
-    }
+    add_farm_visual(&mut app, 5000, true);
+    app.update(); // Added<ProductionState> -> marker spawned
     assert!(
         count_farm_markers(&mut app) > 0,
         "precondition: marker exists"
     );
-    // Set growth_ready to false via ECS
+
+    // Signal harvest via message (mirrors what decision_system emits)
     app.world_mut()
-        .get_mut::<ProductionState>(entity)
-        .unwrap()
-        .ready = false;
-    for _ in 0..4 {
-        app.update();
-    }
-    let count = count_farm_markers(&mut app);
+        .run_system_once(|mut w: MessageWriter<crate::messages::FarmHarvestedMsg>| {
+            w.write(crate::messages::FarmHarvestedMsg { slot: 5000 });
+        })
+        .unwrap();
+    app.update(); // farm_visual_system processes FarmHarvestedMsg -> marker despawned
+
     assert_eq!(
-        count, 0,
-        "marker should be despawned when growth_ready becomes false"
+        count_farm_markers(&mut app),
+        0,
+        "marker should be despawned after harvest message"
     );
 }
 
@@ -1350,32 +1348,28 @@ fn farm_visual_despawns_marker_when_farm_removed_and_allows_slot_reuse() {
     let mut app = setup_farm_visual_app();
     let entity = add_farm_visual(&mut app, 5000, true);
 
-    for _ in 0..4 {
-        app.update();
-    }
+    app.update(); // Added<ProductionState> -> marker spawned
     assert_eq!(
         count_farm_markers(&mut app),
         1,
         "precondition: ready farm should have one marker"
     );
 
+    // Despawn the farm entity; RemovedComponents<ProductionState> cleans up the marker
     app.world_mut().entity_mut(entity).despawn();
     app.world_mut()
         .resource_mut::<EntityMap>()
         .remove_by_slot(5000);
-    for _ in 0..4 {
-        app.update();
-    }
+    app.update(); // RemovedComponents fires -> marker despawned
     assert_eq!(
         count_farm_markers(&mut app),
         0,
         "removing a ready farm should also remove its marker"
     );
 
+    // Re-add farm at same slot (simulating save/load restore or rebuild)
     add_farm_visual(&mut app, 5000, true);
-    for _ in 0..4 {
-        app.update();
-    }
+    app.update(); // Added<ProductionState> -> new marker spawned
     assert_eq!(
         count_farm_markers(&mut app),
         1,
@@ -1384,26 +1378,34 @@ fn farm_visual_despawns_marker_when_farm_removed_and_allows_slot_reuse() {
 }
 
 #[test]
-fn farm_visual_respawns_marker_if_mapping_points_to_stale_entity() {
+fn farm_visual_respawns_marker_after_reload() {
+    // Simulate a save/load cycle: markers are cleared, farms are re-spawned.
+    // Verifies that Added<ProductionState> restores markers for ready farms.
     let mut app = setup_farm_visual_app();
-    add_farm_visual(&mut app, 5000, true);
-    for _ in 0..4 {
-        app.update();
-    }
-    let marker_entity = find_farm_marker(&mut app, 5000).expect("precondition: marker exists");
-    assert!(
-        app.world_mut().despawn(marker_entity),
-        "precondition: marker should despawn externally"
-    );
-
-    for _ in 0..4 {
-        app.update();
-    }
-
+    let entity = add_farm_visual(&mut app, 5000, true);
+    app.update(); // marker spawned
     assert_eq!(
         count_farm_markers(&mut app),
         1,
-        "ready farm should respawn marker after stale mapping is pruned"
+        "precondition: marker exists"
+    );
+
+    // Simulate reload: despawn farm entity + its marker (as save/load systems do)
+    let marker_entity = find_farm_marker(&mut app, 5000).expect("marker should exist");
+    app.world_mut().entity_mut(marker_entity).despawn();
+    app.world_mut().entity_mut(entity).despawn();
+    app.world_mut()
+        .resource_mut::<EntityMap>()
+        .remove_by_slot(5000);
+    app.update(); // process removals
+
+    // Re-spawn farm at same slot (simulating save restore)
+    add_farm_visual(&mut app, 5000, true);
+    app.update(); // Added<ProductionState> -> marker respawned
+    assert_eq!(
+        count_farm_markers(&mut app),
+        1,
+        "marker should respawn for ready farm after reload"
     );
 }
 


### PR DESCRIPTION
Fixes #193.

## Changes

- `messages.rs`: Add `FarmReadyMsg` and `FarmHarvestedMsg` event types
- `lib.rs`: Register both new message types with `add_message`
- `economy/mod.rs`:
  - `growth_system` emits `FarmReadyMsg` at each `production.ready = true` transition (crops, cows, gold mine, tree node, rock node)
  - `farm_visual_system` rewritten: uses `Added<ProductionState>` for init, `RemovedComponents<ProductionState>` for cleanup, and message readers for state transitions - no more polling
- `decision/mod.rs`: `DecisionExtras` gains `farm_visual: MessageWriter<FarmHarvestedMsg>`; all 4 harvest sites emit `FarmHarvestedMsg` when yield > 0
- `economy/tests.rs`: All 5 farm_visual tests updated for event-driven behavior; `setup_growth_app` registers `FarmReadyMsg`
- `decision/tests.rs`: `setup_decision_app` registers `FarmHarvestedMsg`

## Performance

Before: 1.33ms peaks from polling 963 buildings every 4 frames, rebuilding HashMap via `mem::take`, and ~480 `markers.get()` calls on post-load frame.

After: At steady state all 4 queries are empty -- near-zero cost. Post-load handled by `Added<ProductionState>` (processes only newly added components, not all 963).

## Tests

All 331 lib tests pass. 5 dedicated `farm_visual_*` tests cover:
- Marker spawn when farm ready
- No marker when not ready
- Marker despawn on harvest (`FarmHarvestedMsg`)
- Cleanup when farm entity removed (`RemovedComponents`)
- Post-load restore (despawn + respawn simulation)

## Compliance

- **k8s.md**: No architecture violations. No new Def/Instance patterns touched.
- **authority.md**: No GPU-authoritative data used as gameplay gates.
- **performance.md**: Hot-path O(n) scan replaced with O(events) processing. No new anti-patterns introduced. `Local<HashMap>` retained for O(1) marker lookup, never rebuilt.