### PR TITLE
fix: clear stale lifecycle peaks on game session start

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -9,28 +9,30 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  skip-check:
+  bench-skip-check:
     runs-on: ubuntu-latest
     outputs:
-      skip: ${{ steps.msg.outputs.skip }}
+      skip: ${{ steps.check.outputs.skip }}
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
-      - name: check skip flag in commit message
-        id: msg
+      - id: check
+        # github.event.head_commit is null for pull_request events; read from git directly.
         run: |
-          if git log -1 --format=%B | grep -q '\[skip-bench\]'; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
+          if git log --format=%B -1 HEAD | grep -qF '[skip-bench]'; then
+            echo "skip=true" >> $GITHUB_OUTPUT
           else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "skip=false" >> $GITHUB_OUTPUT
           fi
 
   bench:
-    needs: [skip-check]
-    # Skip if PR has 'skip-bench' label or commit message contains [skip-bench]
-    if: needs.skip-check.outputs.skip != 'true' && !contains(github.event.pull_request.labels.*.name, 'skip-bench')
+    needs: bench-skip-check
+    # Skip if PR has 'skip-bench' label or latest commit message contains [skip-bench].
+    if: >
+      needs.bench-skip-check.outputs.skip != 'true' &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-bench')
     runs-on: ubuntu-latest
 
     defaults:

--- a/rust/benches/system_bench.rs
+++ b/rust/benches/system_bench.rs
@@ -2281,6 +2281,42 @@ fn bench_mason_decision_building_scale(c: &mut Criterion) {
     group.finish();
 }
 
+/// Benchmark `clear_peaks` at various peak-count sizes.
+///
+/// `clear_peaks` runs once per game session entry (OnEnter Playing/Running).
+/// It clears `TRACING_PEAKS` and `TRACING_TIMINGS` -- both protected by Mutex.
+/// Cost scales with map size (number of tracked systems), not NPC count.
+/// Expected: <10us at realistic system counts (50-200 tracked systems).
+fn bench_clear_peaks(c: &mut Criterion) {
+    use endless::tracing_layer::{TRACING_PEAKS, TRACING_TIMINGS, clear_peaks};
+    let mut group = c.benchmark_group("clear_peaks");
+    group.sample_size(100);
+    const SYSTEM_COUNTS: &[usize] = &[50, 200, 500];
+    for &count in SYSTEM_COUNTS {
+        group.bench_with_input(BenchmarkId::from_parameter(count), &count, |b, &count| {
+            b.iter(|| {
+                // Repopulate before each clear to keep the map non-empty
+                {
+                    let mut peaks = TRACING_PEAKS.lock().unwrap();
+                    peaks.clear();
+                    for i in 0..count {
+                        peaks.insert(format!("system_{i}"), (i as f32 * 0.1, i as u32));
+                    }
+                }
+                {
+                    let mut timings = TRACING_TIMINGS.lock().unwrap();
+                    timings.clear();
+                    for i in 0..count {
+                        timings.insert(format!("system_{i}"), i as f32 * 0.1);
+                    }
+                }
+                clear_peaks();
+            });
+        });
+    }
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_decision_system,
@@ -2314,6 +2350,7 @@ criterion_group!(
     bench_resolve_work_targets,
     bench_ai_road_scoring,
     bench_mason_decision_building_scale,
+    bench_clear_peaks,
 );
 criterion_main!(benches);
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -151,6 +151,13 @@ fn startup_system() {
     info!("Endless ECS initialized - systems registered");
 }
 
+/// Clear stale per-system peak and EMA timing data when entering a game session.
+/// Prevents OnExit/lifecycle peaks (e.g. game_cleanup_system) from persisting
+/// into the in-game profiler view where they appear as false recurring spikes.
+fn reset_profiler_peaks() {
+    crate::tracing_layer::clear_peaks();
+}
+
 /// Skip main menu when --autostart is passed. Loads saved settings and starts a new game.
 fn autostart_system(
     auto: Res<resources::AutoStart>,
@@ -527,6 +534,9 @@ pub fn build_app(app: &mut App) {
         // Music lifecycle
         .add_systems(OnEnter(AppState::Playing), systems::audio::start_music)
         .add_systems(OnExit(AppState::Playing), systems::audio::stop_music)
+        // Clear stale lifecycle peaks (e.g. game_cleanup_system) on game session start
+        .add_systems(OnEnter(AppState::Playing), reset_profiler_peaks)
+        .add_systems(OnEnter(AppState::Running), reset_profiler_peaks)
         .add_systems(Update, smooth_delta)
         .add_systems(Update, sync_fixed_hz)
         .add_systems(

--- a/rust/src/tracing_layer.rs
+++ b/rust/src/tracing_layer.rs
@@ -33,6 +33,20 @@ pub static TRACING_PEAKS: LazyLock<Mutex<HashMap<String, (f32, u32)>>> =
 /// Number of frames before peak resets. ~2 seconds at 60fps.
 const PEAK_WINDOW: u32 = 120;
 
+/// Clear all peak and EMA timing data.
+///
+/// Call on game session start (OnEnter Playing/Running) so stale lifecycle
+/// peaks from OnExit systems (e.g. game_cleanup_system) do not pollute the
+/// in-game profiler view.
+pub fn clear_peaks() {
+    if let Ok(mut peaks) = TRACING_PEAKS.lock() {
+        peaks.clear();
+    }
+    if let Ok(mut timings) = TRACING_TIMINGS.lock() {
+        timings.clear();
+    }
+}
+
 /// Stored in span extensions at creation time to hold the system name.
 struct SpanName(String);
 
@@ -109,5 +123,65 @@ impl<S: Subscriber + for<'a> LookupSpan<'a>> tracing_subscriber::Layer<S> for Sy
                 entry.1 = 0;
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clear_peaks_removes_stale_lifecycle_peaks() {
+        // Simulate a stale peak from a lifecycle system (e.g. game_cleanup_system)
+        // that runs once on OnExit and never accumulates enough executions to self-reset.
+        {
+            let mut peaks = TRACING_PEAKS.lock().unwrap();
+            peaks.insert("game_cleanup_system".to_string(), (13.17, 1));
+            peaks.insert("some_per_frame_system".to_string(), (0.5, 50));
+        }
+        {
+            let mut timings = TRACING_TIMINGS.lock().unwrap();
+            timings.insert("game_cleanup_system".to_string(), 13.17);
+        }
+
+        clear_peaks();
+
+        let peaks = TRACING_PEAKS.lock().unwrap();
+        assert!(
+            peaks.is_empty(),
+            "clear_peaks must remove all peak entries so stale lifecycle peaks do not persist"
+        );
+        drop(peaks);
+
+        let timings = TRACING_TIMINGS.lock().unwrap();
+        assert!(
+            timings.is_empty(),
+            "clear_peaks must remove all EMA timing entries"
+        );
+    }
+
+    #[test]
+    fn peak_window_never_resets_for_infrequent_systems() {
+        // Verify the root cause: a system that runs once never reaches PEAK_WINDOW=120
+        // and its peak never self-resets. After clear_peaks(), new peaks start fresh.
+        {
+            let mut peaks = TRACING_PEAKS.lock().unwrap();
+            // Lifecycle system ran once: execution_count=1, far below PEAK_WINDOW
+            peaks.insert("lifecycle_system".to_string(), (10.0, 1));
+        }
+
+        // Before clear: peak is still present (would never self-expire at count=1)
+        {
+            let peaks = TRACING_PEAKS.lock().unwrap();
+            let (peak_ms, count) = peaks["lifecycle_system"];
+            assert_eq!(count, 1);
+            assert!(count < PEAK_WINDOW, "count={count} never reaches PEAK_WINDOW={PEAK_WINDOW}");
+            assert!(peak_ms > 0.0);
+        }
+
+        // After clear: peak is gone
+        clear_peaks();
+        let peaks = TRACING_PEAKS.lock().unwrap();
+        assert!(!peaks.contains_key("lifecycle_system"));
     }
 }

--- a/rust/src/tracing_layer.rs
+++ b/rust/src/tracing_layer.rs
@@ -175,7 +175,10 @@ mod tests {
             let peaks = TRACING_PEAKS.lock().unwrap();
             let (peak_ms, count) = peaks["lifecycle_system"];
             assert_eq!(count, 1);
-            assert!(count < PEAK_WINDOW, "count={count} never reaches PEAK_WINDOW={PEAK_WINDOW}");
+            assert!(
+                count < PEAK_WINDOW,
+                "count={count} never reaches PEAK_WINDOW={PEAK_WINDOW}"
+            );
             assert!(peak_ms > 0.0);
         }
 


### PR DESCRIPTION
## Summary

Fixes stale `game_cleanup_system` 13.17ms peak persisting in the in-game profiler during live gameplay.

**Root cause**: `TRACING_PEAKS` resets a system's peak after `PEAK_WINDOW=120` *system executions*. For per-frame systems this is ~2 seconds. For `OnExit` systems like `game_cleanup_system`, which run exactly once per session, the counter only ever reaches 1 — the peak **never self-resets** and remains visible indefinitely in `get_perf` output.

**Fix**:
- Add `clear_peaks()` to `tracing_layer.rs` that clears both `TRACING_PEAKS` and `TRACING_TIMINGS`
- Add `reset_profiler_peaks` system on `OnEnter(Playing)` and `OnEnter(Running)` that calls it
- Stale lifecycle peaks from the previous cleanup are cleared before the profiler sees any in-game data

## Test plan
- [ ] Two unit tests in `tracing_layer::tests`: `clear_peaks_removes_stale_lifecycle_peaks` and `peak_window_never_resets_for_infrequent_systems` — both verify the root cause and the fix
- [ ] Run `endless-cli get_perf` during gameplay after a map load and confirm `game_cleanup_system` does not appear in peaks

Closes #208