### PR TITLE
perf: merge iter_instances passes in resolve_work_targets (#212)

### DIFF
--- a/rust/benches/system_bench.rs
+++ b/rust/benches/system_bench.rs
@@ -21,6 +21,7 @@ use endless::npc_render::{
 use endless::resources::*;
 use endless::systems::ai_player::{AiSnapshotDirty, RoadStyle};
 use endless::systems::stats;
+use endless::systems::work_targeting::resolve_work_targets;
 use endless::systems::{
     AiKind, AiPersonality, AiPlayer, AiPlayerConfig, AiPlayerState, advance_waypoints_system,
     ai_decision_system, arrival_system, attack_system, building_tower_system,
@@ -2000,8 +2001,227 @@ criterion_group!(
     bench_farm_visual_system,
     bench_sync_sleeping_system,
     bench_build_building_body_instances,
+    bench_resolve_work_targets,
 );
 criterion_main!(benches);
+
+/// Populate farm/mine buildings for work targeting benchmarks.
+fn populate_work_buildings(app: &mut App, farm_count: usize, mine_count: usize) {
+    let total = farm_count + mine_count;
+    let world = app.world_mut();
+    let mut building_slots = Vec::with_capacity(total);
+    {
+        let mut pool = world.resource_mut::<GpuSlotPool>();
+        for _ in 0..total {
+            if let Some(slot) = pool.alloc_reset() {
+                building_slots.push(slot);
+            }
+        }
+    }
+    let mut building_entities = Vec::with_capacity(total);
+    for (i, &slot) in building_slots.iter().enumerate() {
+        let x = 200.0 + (i % 100) as f32 * 32.0;
+        let y = 200.0 + (i / 100) as f32 * 32.0;
+        let is_farm = i < farm_count;
+        let kind = if is_farm {
+            world::BuildingKind::Farm
+        } else {
+            world::BuildingKind::GoldMine
+        };
+        let mut cmd = world.spawn((
+            GpuSlot(slot),
+            Position { x, y },
+            Health(100.0),
+            Faction(1),
+            TownId(0),
+            Building { kind },
+            ProductionState {
+                ready: i % 2 == 0,
+                progress: if i % 2 == 0 { 1.0 } else { 0.5 },
+            },
+        ));
+        if is_farm {
+            cmd.insert(FarmModeComp(FarmMode::Crops));
+        }
+        let entity = cmd.id();
+        building_entities.push((entity, slot, x, y, kind));
+    }
+    let mut em = world.resource_mut::<EntityMap>();
+    for &(entity, slot, x, y, kind) in &building_entities {
+        em.set_entity(slot, entity);
+        em.add_instance(endless::entity_map::BuildingInstance {
+            kind,
+            position: Vec2::new(x, y),
+            town_idx: 0,
+            slot,
+            faction: 1,
+        });
+    }
+}
+
+fn bench_resolve_work_targets(c: &mut Criterion) {
+    let mut group = c.benchmark_group("resolve_work_targets");
+    group.sample_size(20);
+
+    const BUILDING_COUNTS: &[usize] = &[500, 2_000, 1_000];
+    const CLAIM_COUNTS: &[usize] = &[50, 200, 200];
+    const RESOURCE_NODE_COUNTS: &[usize] = &[0, 0, 65_000];
+
+    for (idx, (&building_count, &claim_count)) in
+        BUILDING_COUNTS.iter().zip(CLAIM_COUNTS.iter()).enumerate()
+    {
+        let resource_nodes = RESOURCE_NODE_COUNTS[idx];
+        let label = if resource_nodes > 0 {
+            format!("{}_bld_{}k_nodes", building_count, resource_nodes / 1000)
+        } else {
+            format!("{}", building_count)
+        };
+
+        group.bench_with_input(
+            BenchmarkId::new("burst_claim", &label),
+            &building_count,
+            |b, &bcount| {
+                let mut app = build_bench_app();
+                spawn_bench_town(&mut app);
+                populate_npcs(&mut app, claim_count);
+                populate_work_buildings(&mut app, bcount / 2, bcount / 2);
+                if resource_nodes > 0 {
+                    let world = app.world_mut();
+                    let mut node_slots = Vec::with_capacity(resource_nodes);
+                    {
+                        let mut pool = world.resource_mut::<GpuSlotPool>();
+                        for _ in 0..resource_nodes {
+                            if let Some(slot) = pool.alloc_reset() {
+                                node_slots.push(slot);
+                            }
+                        }
+                    }
+                    let mut em = world.resource_mut::<EntityMap>();
+                    for (i, &slot) in node_slots.iter().enumerate() {
+                        let x = 50.0 + (i % 400) as f32 * 40.0;
+                        let y = 50.0 + (i / 400) as f32 * 40.0;
+                        let kind = if i % 2 == 0 {
+                            world::BuildingKind::TreeNode
+                        } else {
+                            world::BuildingKind::RockNode
+                        };
+                        em.add_instance(endless::entity_map::BuildingInstance {
+                            kind,
+                            position: Vec2::new(x, y),
+                            town_idx: 0,
+                            slot,
+                            faction: 0,
+                        });
+                    }
+                }
+                app.world_mut().flush();
+
+                let npc_entities: Vec<Entity> = app
+                    .world_mut()
+                    .run_system_once(
+                        |q: Query<Entity, (Without<Building>, With<NpcWorkState>)>| {
+                            q.iter().collect::<Vec<_>>()
+                        },
+                    )
+                    .unwrap_or_default();
+
+                let _ = app.world_mut().run_system_once(resolve_work_targets);
+
+                b.iter(|| {
+                    let entities = npc_entities.clone();
+                    let _ = app.world_mut().run_system_once(
+                        move |mut writer: MessageWriter<WorkIntentMsg>| {
+                            for &entity in &entities {
+                                writer.write(WorkIntentMsg(WorkIntent::Claim {
+                                    entity,
+                                    kind: world::BuildingKind::Farm,
+                                    town_idx: 0,
+                                    from: Vec2::new(800.0, 800.0),
+                                }));
+                            }
+                        },
+                    );
+                    let _ = app.world_mut().run_system_once(resolve_work_targets);
+                    let _ = app
+                        .world_mut()
+                        .run_system_once(|mut em: ResMut<EntityMap>| {
+                            for slot in em.iter_instances().map(|i| i.slot).collect::<Vec<_>>() {
+                                em.set_occupancy(slot, 0);
+                            }
+                        });
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("release_only", &label),
+            &building_count,
+            |b, &bcount| {
+                let mut app = build_bench_app();
+                spawn_bench_town(&mut app);
+                populate_npcs(&mut app, claim_count);
+                populate_work_buildings(&mut app, bcount / 2, bcount / 2);
+                if resource_nodes > 0 {
+                    let world = app.world_mut();
+                    let mut node_slots = Vec::with_capacity(resource_nodes);
+                    {
+                        let mut pool = world.resource_mut::<GpuSlotPool>();
+                        for _ in 0..resource_nodes {
+                            if let Some(slot) = pool.alloc_reset() {
+                                node_slots.push(slot);
+                            }
+                        }
+                    }
+                    let mut em = world.resource_mut::<EntityMap>();
+                    for (i, &slot) in node_slots.iter().enumerate() {
+                        let x = 50.0 + (i % 400) as f32 * 40.0;
+                        let y = 50.0 + (i / 400) as f32 * 40.0;
+                        let kind = if i % 2 == 0 {
+                            world::BuildingKind::TreeNode
+                        } else {
+                            world::BuildingKind::RockNode
+                        };
+                        em.add_instance(endless::entity_map::BuildingInstance {
+                            kind,
+                            position: Vec2::new(x, y),
+                            town_idx: 0,
+                            slot,
+                            faction: 0,
+                        });
+                    }
+                }
+                app.world_mut().flush();
+
+                let npc_entities: Vec<Entity> = app
+                    .world_mut()
+                    .run_system_once(
+                        |q: Query<Entity, (Without<Building>, With<NpcWorkState>)>| {
+                            q.iter().collect::<Vec<_>>()
+                        },
+                    )
+                    .unwrap_or_default();
+
+                let _ = app.world_mut().run_system_once(resolve_work_targets);
+
+                b.iter(|| {
+                    let entities = npc_entities.clone();
+                    let _ = app.world_mut().run_system_once(
+                        move |mut writer: MessageWriter<WorkIntentMsg>| {
+                            for &entity in &entities {
+                                writer.write(WorkIntentMsg(WorkIntent::Release {
+                                    entity,
+                                    worksite: None,
+                                }));
+                            }
+                        },
+                    );
+                    let _ = app.world_mut().run_system_once(resolve_work_targets);
+                });
+            },
+        );
+    }
+    group.finish();
+}
 
 fn bench_build_building_body_instances(c: &mut Criterion) {
     let mut group = c.benchmark_group("build_building_body_instances");

--- a/rust/src/systems/work_targeting.rs
+++ b/rust/src/systems/work_targeting.rs
@@ -29,31 +29,38 @@ pub fn resolve_work_targets(
         return;
     }
 
-    // Pre-collect production state only when there are messages to process.
-    // Only Claim/Retarget need it, but building the map is cheaper than checking each message type.
-    let production_map: std::collections::HashMap<usize, (bool, f32)> = entity_map
-        .iter_instances()
-        .filter_map(|inst| {
-            let entity = entity_map.entities.get(&inst.slot)?;
-            let ps = production_q.get(*entity).ok()?;
-            Some((inst.slot, (ps.ready, ps.progress)))
-        })
-        .collect();
+    // Only Claim/Retarget need the production and cow-farm maps; skip the building scan
+    // entirely for Release/MarkPresent-only batches (the common steady-state path).
+    let needs_claim_data = msgs.iter().any(|WorkIntentMsg(intent)| {
+        matches!(
+            intent,
+            WorkIntent::Claim { .. } | WorkIntent::Retarget { .. }
+        )
+    });
 
-    // Pre-collect cow farm slots so farmers skip them during targeting.
-    let cow_farm_slots: std::collections::HashSet<usize> = entity_map
-        .iter_instances()
-        .filter(|inst| inst.kind == BuildingKind::Farm)
-        .filter_map(|inst| {
-            let entity = entity_map.entities.get(&inst.slot)?;
-            let fm = farm_mode_q.get(*entity).ok()?;
-            if fm.0 == FarmMode::Cows {
-                Some(inst.slot)
-            } else {
-                None
+    // Single pass over all building instances to build both maps simultaneously.
+    // Replaces the previous two separate iter_instances() passes.
+    let mut production_map: std::collections::HashMap<usize, (bool, f32)> =
+        std::collections::HashMap::new();
+    let mut cow_farm_slots: std::collections::HashSet<usize> = std::collections::HashSet::new();
+
+    if needs_claim_data {
+        for inst in entity_map.iter_instances() {
+            let Some(&entity) = entity_map.entities.get(&inst.slot) else {
+                continue;
+            };
+            if let Ok(ps) = production_q.get(entity) {
+                production_map.insert(inst.slot, (ps.ready, ps.progress));
             }
-        })
-        .collect();
+            if inst.kind == BuildingKind::Farm {
+                if let Ok(fm) = farm_mode_q.get(entity) {
+                    if fm.0 == FarmMode::Cows {
+                        cow_farm_slots.insert(inst.slot);
+                    }
+                }
+            }
+        }
+    }
 
     for WorkIntentMsg(intent) in msgs {
         match intent {

--- a/rust/src/systems/work_targeting.rs
+++ b/rust/src/systems/work_targeting.rs
@@ -322,3 +322,164 @@ fn find_node_target(
         )
         .map(|r| (r.slot, r.position, r.radius_used))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy_ecs::system::RunSystemOnce;
+
+    use crate::components::{
+        Activity, Building, FarmMode, FarmModeComp, GpuSlot, Health, NpcWorkState, Position,
+        ProductionState,
+    };
+    use crate::entity_map::BuildingInstance;
+    use crate::messages::{WorkIntent, WorkIntentMsg};
+    use crate::resources::{EntityMap, GpuSlotPool, PathRequestQueue};
+    use crate::world::BuildingKind;
+    use bevy::prelude::*;
+
+    fn setup_work_app() -> App {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_message::<WorkIntentMsg>();
+        app.init_resource::<EntityMap>();
+        app.init_resource::<PathRequestQueue>();
+        app.init_resource::<GpuSlotPool>();
+        {
+            let mut em = app.world_mut().resource_mut::<EntityMap>();
+            em.init_spatial(1600.0);
+        }
+        app
+    }
+
+    fn alloc_slot(app: &mut App) -> usize {
+        app.world_mut()
+            .resource_mut::<GpuSlotPool>()
+            .alloc_reset()
+            .expect("slot available")
+    }
+
+    fn register_farm(
+        app: &mut App,
+        slot: usize,
+        x: f32,
+        y: f32,
+        mode: FarmMode,
+        production_ready: bool,
+    ) -> Entity {
+        let entity = app
+            .world_mut()
+            .spawn((
+                GpuSlot(slot),
+                Position { x, y },
+                Health(100.0),
+                crate::components::Faction(1),
+                crate::components::TownId(0),
+                Building {
+                    kind: BuildingKind::Farm,
+                },
+                ProductionState {
+                    ready: production_ready,
+                    progress: 1.0,
+                },
+                FarmModeComp(mode),
+            ))
+            .id();
+        let mut em = app.world_mut().resource_mut::<EntityMap>();
+        em.set_entity(slot, entity);
+        em.add_instance(BuildingInstance {
+            kind: BuildingKind::Farm,
+            position: Vec2::new(x, y),
+            town_idx: 0,
+            slot,
+            faction: 1,
+        });
+        entity
+    }
+
+    /// Verify the merged single-pass correctly populates cow_farm_slots:
+    /// a farmer claiming a Farm should receive the Crops farm, not the Cows farm.
+    /// This test would fail if the cow-farm exclusion were dropped from the merged pass.
+    #[test]
+    fn claim_skips_cow_farm_assigns_crops_farm() {
+        let mut app = setup_work_app();
+
+        let crops_slot = alloc_slot(&mut app);
+        let cows_slot = alloc_slot(&mut app);
+        let npc_slot = alloc_slot(&mut app);
+
+        let crops_farm = register_farm(&mut app, crops_slot, 100.0, 100.0, FarmMode::Crops, true);
+        let _cows_farm = register_farm(&mut app, cows_slot, 110.0, 100.0, FarmMode::Cows, true);
+
+        let npc = app
+            .world_mut()
+            .spawn((
+                GpuSlot(npc_slot),
+                Activity::default(),
+                NpcWorkState::default(),
+            ))
+            .id();
+
+        let _ = app
+            .world_mut()
+            .run_system_once(move |mut writer: MessageWriter<WorkIntentMsg>| {
+                writer.write(WorkIntentMsg(WorkIntent::Claim {
+                    entity: npc,
+                    kind: BuildingKind::Farm,
+                    town_idx: 0,
+                    from: Vec2::new(0.0, 0.0),
+                }));
+            });
+        let _ = app.world_mut().run_system_once(resolve_work_targets);
+
+        let ws = app.world().get::<NpcWorkState>(npc).unwrap();
+        assert!(
+            ws.worksite.is_some(),
+            "farmer should be assigned a worksite"
+        );
+        assert_eq!(
+            ws.worksite.unwrap(),
+            crops_farm,
+            "farmer must claim the Crops farm, not the Cows farm"
+        );
+    }
+
+    /// Verify Release-only batch clears NpcWorkState without panicking.
+    /// This test would fail if Release handling were broken by the lazy gate.
+    #[test]
+    fn release_clears_worksite() {
+        let mut app = setup_work_app();
+
+        let crops_slot = alloc_slot(&mut app);
+        let npc_slot = alloc_slot(&mut app);
+
+        let crops_farm = register_farm(&mut app, crops_slot, 100.0, 100.0, FarmMode::Crops, true);
+
+        let npc = app
+            .world_mut()
+            .spawn((
+                GpuSlot(npc_slot),
+                Activity::default(),
+                NpcWorkState {
+                    worksite: Some(crops_farm),
+                },
+            ))
+            .id();
+
+        let _ = app
+            .world_mut()
+            .run_system_once(move |mut writer: MessageWriter<WorkIntentMsg>| {
+                writer.write(WorkIntentMsg(WorkIntent::Release {
+                    entity: npc,
+                    worksite: Some(crops_farm),
+                }));
+            });
+        let _ = app.world_mut().run_system_once(resolve_work_targets);
+
+        let ws = app.world().get::<NpcWorkState>(npc).unwrap();
+        assert!(
+            ws.worksite.is_none(),
+            "worksite should be cleared after Release"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Merged two separate `iter_instances()` passes in `resolve_work_targets` into a single pass
- Added lazy `needs_claim_data` gate: Release/MarkPresent-only batches skip the building scan entirely (zero preamble cost for the common steady-state path)
- Added `bench_resolve_work_targets` to `system_bench.rs` with `burst_claim` and `release_only` scenarios at 500 and 2000 building counts

## Root Cause

`resolve_work_targets` built `production_map` and `cow_farm_slots` via two separate `iter_instances()` traversals (each with an ECS query `.get()` per building) unconditionally on every non-empty message batch. This paid O(n_buildings) twice even for Release-only or MarkPresent-only batches, which never need either map.

The spike (2.22ms vs 0.33ms steady-state) occurs when a burst of Claim messages arrives simultaneously (e.g., after a mass respawn); the double building scan runs before every per-claim spatial search.

## Fix

Single pass + lazy construction:
- Check if any Claim/Retarget message exists before touching buildings
- If yes, one `iter_instances()` pass builds both `production_map` and `cow_farm_slots` simultaneously
- Reduces Release/MarkPresent-only batch preamble to O(1); reduces Claim/Retarget batch preamble from 2x to 1x building scan

## Compliance

- `docs/k8s.md`: no changes to Def/Instance/Controller structure; building instances still accessed via EntityMap
- `docs/authority.md`: no changes to data ownership; CPU-authoritative fields read via ECS as before
- `docs/performance.md`: fixes "Redundant traversals" anti-pattern (multiple passes over same collection replaced by single pass). No new hot-path violations.

## Before/After

In-game: system peaks at 2.22ms (observed via `endless-cli get_perf`), steady-state 0.33ms.  
After fix: Release-only batches skip building scan entirely; Claim batches pay half the previous preamble cost.  
Needs BRP in-game profiling on real hardware to confirm after metric.

Benchmark command: `cargo bench --bench system_bench -- resolve_work_targets`

## Test plan

- [x] `cargo check` passes
- [x] `cargo clippy --release -- -D warnings` passes clean
- [x] `cargo fmt` applied
- [x] `cargo check --bench system_bench` passes
- [ ] Before/after in-game `endless-cli get_perf` timing (needs local game run)
- [ ] `bench_resolve_work_targets` benchmark results recorded in `docs/performance.md`

Fixes #212