### PR TITLE
perf: fix O(n*m) adjacency in road candidate scoring (issue-210)

### DIFF
--- a/rust/benches/system_bench.rs
+++ b/rust/benches/system_bench.rs
@@ -2002,6 +2002,7 @@ criterion_group!(
     bench_sync_sleeping_system,
     bench_build_building_body_instances,
     bench_resolve_work_targets,
+    bench_ai_road_scoring,
 );
 criterion_main!(benches);
 
@@ -2416,5 +2417,81 @@ fn bench_sync_sleeping_system(c: &mut Criterion) {
             },
         );
     }
+    group.finish();
+}
+
+fn bench_ai_road_scoring(c: &mut Criterion) {
+    let npc_count = 1_000;
+    let mut group = c.benchmark_group("ai_road_scoring");
+    group.sample_size(20);
+    group.bench_function("grid_style_18_towns", |b| {
+        let mut app = build_bench_app();
+        app.init_resource::<AiSnapshotDirty>();
+        spawn_ai_bench_world(&mut app, npc_count);
+        {
+            let world = app.world_mut();
+            let town_centers: Vec<(Vec2, usize)> = (0..AI_TOWN_COUNT)
+                .map(|i| {
+                    let cx = (i % 6) as f32 * 1200.0 + 600.0;
+                    let cy = (i / 6) as f32 * 1200.0 + 600.0;
+                    (Vec2::new(cx, cy), i)
+                })
+                .collect();
+            {
+                let mut grid = world.resource_mut::<world::WorldGrid>();
+                for &(center, town_idx) in &town_centers {
+                    let (cc, cr) = grid.world_to_grid(center);
+                    for dr in -4i32..=3 {
+                        for dc in -4i32..=3 {
+                            let col = cc as i32 + dc;
+                            let row = cr as i32 + dr;
+                            if col >= 0 && row >= 0 {
+                                grid.add_town_buildable(col as usize, row as usize, town_idx as u16);
+                            }
+                        }
+                    }
+                }
+            }
+            let farm_instances: Vec<(usize, Vec2, u32, i32)> = {
+                let mut pool = world.resource_mut::<GpuSlotPool>();
+                let mut instances = Vec::new();
+                for &(center, town_idx) in &town_centers {
+                    let faction = (town_idx + 1) as i32;
+                    for k in 0..8usize {
+                        let Some(slot) = pool.alloc_reset() else { break };
+                        let dx = (k % 4) as f32 * TOWN_GRID_SPACING - TOWN_GRID_SPACING * 1.5;
+                        let dy = (k / 4) as f32 * TOWN_GRID_SPACING - TOWN_GRID_SPACING * 0.5;
+                        instances.push((slot, Vec2::new(center.x + dx, center.y + dy), town_idx as u32, faction));
+                    }
+                }
+                instances
+            };
+            let mut em = world.resource_mut::<EntityMap>();
+            for (slot, pos, town_idx, faction) in farm_instances {
+                em.add_instance(endless::entity_map::BuildingInstance {
+                    kind: world::BuildingKind::Farm, position: pos, town_idx, slot, faction,
+                });
+            }
+        }
+        {
+            let world = app.world_mut();
+            let mut ai_state = world.resource_mut::<AiPlayerState>();
+            for (i, p) in ai_state.players.iter_mut().enumerate() {
+                p.road_style = RoadStyle::Grid4;
+                p.decision_timer = if i == 0 { DEFAULT_AI_INTERVAL } else { i as f32 * DEFAULT_AI_INTERVAL / AI_TOWN_COUNT as f32 };
+            }
+        }
+        let _ = app.world_mut().run_system_once(ai_decision_system);
+        b.iter(|| {
+            {
+                let world = app.world_mut();
+                let mut ai_state = world.resource_mut::<AiPlayerState>();
+                for (i, p) in ai_state.players.iter_mut().enumerate() {
+                    p.decision_timer = if i == 0 { DEFAULT_AI_INTERVAL } else { i as f32 * DEFAULT_AI_INTERVAL / AI_TOWN_COUNT as f32 };
+                }
+            }
+            let _ = app.world_mut().run_system_once(ai_decision_system);
+        });
+    });
     group.finish();
 }

--- a/rust/src/systems/ai_player/build_actions.rs
+++ b/rust/src/systems/ai_player/build_actions.rs
@@ -196,6 +196,15 @@ pub(super) fn count_road_candidates(
     .flat_map(|&kind| entity_map.iter_kind_for_town(kind, ti))
     .map(|b| grid.world_to_grid(b.position))
     .collect();
+    // Precompute expanded adjacency set: each econ slot expanded by radius 2.
+    // Converts O(grid_cells * econ_buildings) adjacency check to O(1) per cell.
+    let econ_adj: HashSet<(i32, i32)> = econ_slots
+        .iter()
+        .flat_map(|&(ec, er)| {
+            (-2i32..=2)
+                .flat_map(move |dc| (-2i32..=2).map(move |dr| (ec as i32 + dc, er as i32 + dr)))
+        })
+        .collect();
     let (min_c, max_c, min_r, max_r) = world::build_bounds(area_level, center, grid);
     // Cardinal: extend axes to 2x build radius for attack corridors
     let (ext_min_c, ext_max_c, ext_min_r, ext_max_r) = if road_style == RoadStyle::Cardinal {
@@ -223,9 +232,7 @@ pub(super) fn count_road_candidates(
                 continue;
             }
             let in_bounds = col >= min_c && col <= max_c && row >= min_r && row <= max_r;
-            let adj = econ_slots.iter().any(|&(ec, er)| {
-                (ec as i32 - col as i32).abs() <= 2 && (er as i32 - row as i32).abs() <= 2
-            });
+            let adj = econ_adj.contains(&(col as i32, row as i32));
             if adj || !in_bounds {
                 count += 1;
             }
@@ -268,6 +275,18 @@ pub(super) fn try_build_road_grid(
     .map(|b| grid.world_to_grid(b.position))
     .collect();
 
+    // Precompute adjacency counts: each econ slot votes for its radius-2 neighbors.
+    // Converts O(grid_cells * econ_buildings) to O(econ_buildings * 25 + grid_cells).
+    let mut econ_adj_counts: HashMap<(i32, i32), i32> = HashMap::new();
+    for &(ec, er) in &econ_slots {
+        for dc in -2i32..=2 {
+            for dr in -2i32..=2 {
+                *econ_adj_counts
+                    .entry((ec as i32 + dc, er as i32 + dr))
+                    .or_default() += 1;
+            }
+        }
+    }
     let mut candidates: HashMap<(usize, usize), i32> = HashMap::new();
     let (min_c, max_c, min_r, max_r) =
         world::build_bounds(ctx.area_level, ctx.center, &res.world.grid);
@@ -294,12 +313,10 @@ pub(super) fn try_build_road_grid(
                 continue;
             }
             let in_bounds = col >= min_c && col <= max_c && row >= min_r && row <= max_r;
-            let adj = econ_slots
-                .iter()
-                .filter(|&&(ec, er)| {
-                    (ec as i32 - col as i32).abs() <= 2 && (er as i32 - row as i32).abs() <= 2
-                })
-                .count() as i32;
+            let adj = econ_adj_counts
+                .get(&(col as i32, row as i32))
+                .copied()
+                .unwrap_or(0);
             if adj > 0 {
                 candidates.insert((col, row), adj);
             } else if !in_bounds {
@@ -543,4 +560,178 @@ pub(super) fn log_ai(
         message: format!("{} [{}] {}", town, personality, what),
         location: None,
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy::prelude::Vec2;
+
+    fn make_grid(size: usize) -> world::WorldGrid {
+        let mut grid = world::WorldGrid::default();
+        grid.width = size;
+        grid.height = size;
+        grid.cell_size = crate::constants::TOWN_GRID_SPACING;
+        grid.cells = vec![world::WorldCell::default(); size * size];
+        grid.init_town_buildable();
+        grid
+    }
+
+    /// count_road_candidates returns 0 when there are no econ buildings.
+    /// Verifies early-return path is not broken by the adjacency precompute.
+    #[test]
+    fn count_road_candidates_zero_with_no_econ_buildings() {
+        let em = EntityMap::default();
+        let grid = make_grid(20);
+        let center = Vec2::new(640.0, 640.0);
+        let count = count_road_candidates(&em, 1, center, &grid, 0, RoadStyle::Grid4);
+        assert_eq!(count, 0);
+    }
+
+    /// count_road_candidates finds road slots adjacent to econ buildings.
+    /// This test would FAIL if the HashSet precompute returned wrong results
+    /// compared to the original iter().any() brute-force check.
+    #[test]
+    fn count_road_candidates_finds_slots_near_farm() {
+        let mut em = EntityMap::default();
+        em.init_spatial(2000.0);
+        let mut grid = make_grid(20);
+        let center = Vec2::new(640.0, 640.0); // cell (10, 10)
+        let ti = 0u32;
+
+        // Mark build-area cells as buildable for town 0
+        for dr in -4i32..=3i32 {
+            for dc in -4i32..=3i32 {
+                let col = 10i32 + dc;
+                let row = 10i32 + dr;
+                if col >= 0 && row >= 0 {
+                    grid.add_town_buildable(col as usize, row as usize, 0u16);
+                }
+            }
+        }
+
+        // Add a farm at cell (8, 10): world pos = (8*64, 10*64) = (512, 640)
+        let mut pool = crate::resources::GpuSlotPool::default();
+        let slot = pool.alloc_reset().unwrap();
+        em.add_instance(crate::entity_map::BuildingInstance {
+            kind: world::BuildingKind::Farm,
+            position: Vec2::new(512.0, 640.0),
+            town_idx: ti,
+            slot,
+            faction: 1,
+        });
+
+        let count = count_road_candidates(&em, 1, center, &grid, ti, RoadStyle::Grid4);
+        assert!(count > 0, "expected road candidates near farm; got {count}");
+    }
+
+    /// count_road_candidates result matches a brute-force reference impl.
+    /// If the HashSet precompute changes which cells count, this catches it.
+    #[test]
+    fn count_road_candidates_matches_brute_force() {
+        let mut em = EntityMap::default();
+        em.init_spatial(2000.0);
+        let mut grid = make_grid(20);
+        let center = Vec2::new(640.0, 640.0);
+        let ti = 0u32;
+
+        for dr in -4i32..=3i32 {
+            for dc in -4i32..=3i32 {
+                let col = 10i32 + dc;
+                let row = 10i32 + dr;
+                if col >= 0 && row >= 0 {
+                    grid.add_town_buildable(col as usize, row as usize, 0u16);
+                }
+            }
+        }
+
+        let mut pool = crate::resources::GpuSlotPool::default();
+        for k in 0..5usize {
+            let slot = pool.alloc_reset().unwrap();
+            let x = (8 + k) as f32 * crate::constants::TOWN_GRID_SPACING;
+            let y = 10.0 * crate::constants::TOWN_GRID_SPACING;
+            em.add_instance(crate::entity_map::BuildingInstance {
+                kind: world::BuildingKind::Farm,
+                position: Vec2::new(x, y),
+                town_idx: ti,
+                slot,
+                faction: 1,
+            });
+        }
+
+        let count_new = count_road_candidates(&em, 1, center, &grid, ti, RoadStyle::Grid4);
+        // Brute-force reference: same logic without the precompute optimization
+        let count_ref =
+            count_road_candidates_brute_force(&em, 1, center, &grid, ti, RoadStyle::Grid4);
+        assert_eq!(
+            count_new, count_ref,
+            "optimized count {count_new} != brute-force {count_ref}"
+        );
+    }
+
+    /// Reference implementation of count_road_candidates using the original
+    /// O(cells * econ_buildings) adjacency check. Used to validate the O(1) precompute.
+    fn count_road_candidates_brute_force(
+        entity_map: &EntityMap,
+        area_level: i32,
+        center: Vec2,
+        grid: &world::WorldGrid,
+        ti: u32,
+        road_style: RoadStyle,
+    ) -> usize {
+        let (cc, cr) = grid.world_to_grid(center);
+        let econ_slots: Vec<(usize, usize)> = entity_map
+            .iter_kind_for_town(BuildingKind::Farm, ti)
+            .chain(entity_map.iter_kind_for_town(BuildingKind::FarmerHome, ti))
+            .chain(entity_map.iter_kind_for_town(BuildingKind::MinerHome, ti))
+            .map(|b| grid.world_to_grid(b.position))
+            .collect();
+        if econ_slots.is_empty() {
+            return 0;
+        }
+        let road_slots: HashSet<(usize, usize)> = [
+            BuildingKind::Road,
+            BuildingKind::StoneRoad,
+            BuildingKind::MetalRoad,
+        ]
+        .iter()
+        .flat_map(|&kind| entity_map.iter_kind_for_town(kind, ti))
+        .map(|b| grid.world_to_grid(b.position))
+        .collect();
+        let (min_c, max_c, min_r, max_r) = world::build_bounds(area_level, center, grid);
+        let (ext_min_c, ext_max_c, ext_min_r, ext_max_r) = if road_style == RoadStyle::Cardinal {
+            let half_c = cc - min_c;
+            let half_r = cr - min_r;
+            (
+                cc.saturating_sub(half_c * 2),
+                max_c + half_c,
+                cr.saturating_sub(half_r * 2),
+                max_r + half_r,
+            )
+        } else {
+            (min_c, max_c, min_r, max_r)
+        };
+        let mut count = 0usize;
+        for row in ext_min_r..=ext_max_r {
+            for col in ext_min_c..=ext_max_c {
+                if !road_style.is_road_slot(col, row, cc, cr) {
+                    continue;
+                }
+                if road_slots.contains(&(col, row)) {
+                    continue;
+                }
+                if entity_map.has_building_at(col as i32, row as i32) {
+                    continue;
+                }
+                let in_bounds = col >= min_c && col <= max_c && row >= min_r && row <= max_r;
+                let adj = econ_slots.iter().any(|&(ec, er)| {
+                    (ec as i32 - col as i32).abs() <= 2 && (er as i32 - row as i32).abs() <= 2
+                });
+                if adj || !in_bounds {
+                    count += 1;
+                }
+            }
+        }
+        count
+    }
 }


### PR DESCRIPTION
## Problem

`ai_decision_system` peaks at 4.51ms during active gameplay. Root cause identified: `count_road_candidates` and `try_build_road_grid` both contain an O(cells * econ_buildings) inner loop that iterates all econ buildings for every grid cell to check adjacency. This is a textbook hot-path O(n^2) pattern flagged in performance.md.

## Fix

Precompute an expanded HashSet/HashMap from econ slots (each slot expanded by radius 2 in all directions) before the grid scan. Per-cell adjacency check becomes O(1) instead of O(econ_buildings).

**count_road_candidates**: `econ_slots.iter().any(...)` per cell -> `econ_adj.contains(...)` O(1)
**try_build_road_grid**: `econ_slots.iter().filter(...).count()` per cell -> `econ_adj_counts.get(...)` O(1)

Complexity: O(cells * econ) -> O(econ * 25 + cells)

## Benchmark

Added `bench_ai_road_scoring` in `system_bench.rs` targeting the road path with Grid4 style and 8 econ buildings per town. NOTE: benchmark must be run locally (k3s pods lack GPU/ALSA). Expected improvement: measurable reduction per town when road style is non-None.

## Tests

Three unit tests in `build_actions.rs`:
- `count_road_candidates_zero_with_no_econ_buildings`: verifies early-return still works
- `count_road_candidates_finds_slots_near_farm`: verifies result is non-zero with a farm building
- `count_road_candidates_matches_brute_force`: verifies optimized result exactly matches original O(n*m) implementation (regression guard)

NOTE: Tests compile clean but cannot link in k3s pods (missing ALSA). Must be run locally.

## Compliance

- docs/performance.md: fix eliminates O(n^2) hot-path pattern (nested membership check anti-pattern)
- docs/k8s.md: no registry/def/instance pattern changes
- docs/authority.md: no data ownership changes

## Acceptance Criteria

- [x] Identify concrete source: O(n*m) adjacency check in count_road_candidates and try_build_road_grid
- [ ] Before metrics: needs local BRP measurement (k3s pods cannot run game)
- [x] Criterion benchmark added: bench_ai_road_scoring in system_bench.rs
- [ ] After metrics: needs local benchmark run to record before/after numbers
- [ ] Before/after benchmark results recorded
- [x] Compliance verified
- [x] No new hot-path violations

Open: before/after perf metrics and benchmark results require local execution (no GPU/ALSA in k3s).