### PR TITLE
fix: replace hardcoded tower kind chain with registry-based filter

### DIFF
--- a/rust/src/systems/combat.rs
+++ b/rust/src/systems/combat.rs
@@ -863,10 +863,11 @@ pub fn building_tower_system(
         BuildingKind,
         f32,
     )> = entity_map
-        .iter_kind(BuildingKind::BowTower)
-        .chain(entity_map.iter_kind(BuildingKind::CrossbowTower))
-        .chain(entity_map.iter_kind(BuildingKind::CatapultTower))
-        .chain(entity_map.iter_kind(BuildingKind::GuardTower))
+        .iter_instances()
+        .filter(|i| {
+            let def = crate::constants::building_def(i.kind);
+            def.is_tower && i.kind != BuildingKind::Fountain
+        })
         .filter_map(|inst| {
             let entity = *entity_map.entities.get(&inst.slot)?;
             let tbs = tower_bld_q.get(entity).ok()?;
@@ -1603,5 +1604,73 @@ mod tests {
             result, 5,
             "neutral-faction candidate must never be selected"
         );
+    }
+
+    // -- tower collection: registry-based filter ----------------------------
+
+    /// Regression: tower combat collection uses registry is_tower flag, not a hardcoded kind list.
+    /// Verifies that iter_instances().filter(is_tower) returns exactly the tower-flagged buildings
+    /// registered in BUILDING_REGISTRY (excluding Fountain), and excludes non-tower buildings.
+    #[test]
+    fn tower_collection_uses_registry_is_tower_filter() {
+        use crate::constants::{BUILDING_REGISTRY, building_def};
+        use crate::resources::BuildingInstance;
+
+        let mut em = EntityMap::default();
+
+        // Register one instance per is_tower kind (excluding Fountain).
+        let tower_kinds: Vec<_> = BUILDING_REGISTRY
+            .iter()
+            .filter(|d| d.is_tower && d.kind != BuildingKind::Fountain)
+            .map(|d| d.kind)
+            .collect();
+
+        for (slot, &kind) in tower_kinds.iter().enumerate() {
+            em.add_instance(BuildingInstance {
+                kind,
+                position: Vec2::ZERO,
+                town_idx: 0,
+                slot,
+                faction: 1,
+            });
+        }
+
+        // Also register a non-tower building to verify it is excluded.
+        let non_tower_kind = crate::world::BuildingKind::Farm;
+        assert!(
+            !building_def(non_tower_kind).is_tower,
+            "Farm must not be a tower for this test to be valid"
+        );
+        em.add_instance(BuildingInstance {
+            kind: non_tower_kind,
+            position: Vec2::ZERO,
+            town_idx: 0,
+            slot: tower_kinds.len(),
+            faction: 1,
+        });
+
+        let filtered: Vec<_> = em
+            .iter_instances()
+            .filter(|i| {
+                let def = building_def(i.kind);
+                def.is_tower && i.kind != BuildingKind::Fountain
+            })
+            .collect();
+
+        assert_eq!(
+            filtered.len(),
+            tower_kinds.len(),
+            "registry-based filter must return exactly all is_tower buildings (got {}, expected {})",
+            filtered.len(),
+            tower_kinds.len()
+        );
+
+        for kind in &tower_kinds {
+            assert!(
+                filtered.iter().any(|i| i.kind == *kind),
+                "tower kind {:?} must be included by registry-based filter",
+                kind
+            );
+        }
     }
 }

--- a/rust/src/systems/pathfinding.rs
+++ b/rust/src/systems/pathfinding.rs
@@ -1276,12 +1276,18 @@ mod tests {
         place_wall(&mut entity_map, 3, 3, wall_slot);
         grid.sync_building_costs(&entity_map);
         let idx = 3 * grid.width + 3;
-        assert_eq!(grid.pathfind_costs[idx], 0, "wall cell should be impassable after placement");
+        assert_eq!(
+            grid.pathfind_costs[idx], 0,
+            "wall cell should be impassable after placement"
+        );
 
         entity_map.remove_by_slot(wall_slot);
         grid.sync_building_costs(&entity_map);
         let terrain_cost = crate::world::terrain_base_cost(crate::world::Biome::Grass);
-        assert_eq!(grid.pathfind_costs[idx], terrain_cost, "wall cell should revert to terrain cost after removal");
+        assert_eq!(
+            grid.pathfind_costs[idx], terrain_cost,
+            "wall cell should revert to terrain cost after removal"
+        );
     }
 
     /// Regression: two sequential sync calls produce correct cumulative costs.
@@ -1292,18 +1298,31 @@ mod tests {
         place_wall(&mut entity_map, 2, 2, 401);
         grid.sync_building_costs(&entity_map);
         let wall_idx = 2 * grid.width + 2;
-        assert_eq!(grid.pathfind_costs[wall_idx], 0, "wall should be impassable");
+        assert_eq!(
+            grid.pathfind_costs[wall_idx], 0,
+            "wall should be impassable"
+        );
 
         entity_map.add_instance(crate::resources::BuildingInstance {
             kind: crate::world::BuildingKind::Road,
             position: Vec2::new(5.0 * 64.0 + 32.0, 5.0 * 64.0 + 32.0),
-            slot: 402, town_idx: 0, faction: 0,
+            slot: 402,
+            town_idx: 0,
+            faction: 0,
         });
         grid.sync_building_costs(&entity_map);
-        assert_eq!(grid.pathfind_costs[wall_idx], 0, "wall should remain impassable after second sync");
+        assert_eq!(
+            grid.pathfind_costs[wall_idx], 0,
+            "wall should remain impassable after second sync"
+        );
         let road_idx = 5 * grid.width + 5;
-        let road_cost = crate::world::BuildingKind::Road.road_pathfind_cost().unwrap();
-        assert_eq!(grid.pathfind_costs[road_idx], road_cost, "road cell should have road cost after second sync");
+        let road_cost = crate::world::BuildingKind::Road
+            .road_pathfind_cost()
+            .unwrap();
+        assert_eq!(
+            grid.pathfind_costs[road_idx], road_cost,
+            "road cell should have road cost after second sync"
+        );
     }
 
     /// Regression test for issue #203: only pass changed cells to rebuild_chunks.
@@ -1318,22 +1337,52 @@ mod tests {
         assert_eq!(after_first.len(), 1, "one building cell after first sync");
         let wall_idx = 5 * grid.width + 5;
         assert_eq!(after_first[0], wall_idx, "wall cell recorded");
-        let rebuild_after_add = grid.hpa_cache.as_ref().map(|c| c.rebuild_count).unwrap_or(0);
-        assert_eq!(rebuild_after_add, 1, "rebuild_chunks called once on wall add");
+        let rebuild_after_add = grid
+            .hpa_cache
+            .as_ref()
+            .map(|c| c.rebuild_count)
+            .unwrap_or(0);
+        assert_eq!(
+            rebuild_after_add, 1,
+            "rebuild_chunks called once on wall add"
+        );
 
         grid.sync_building_costs(&entity_map);
         let after_second: Vec<usize> = grid.dirty_cost_cells().to_vec();
         assert_eq!(after_second.len(), 1, "same one cell after no-op sync");
-        assert!(grid.pathfind_costs[wall_idx] == 0, "wall cell must be impassable after no-op sync");
-        let rebuild_after_noop = grid.hpa_cache.as_ref().map(|c| c.rebuild_count).unwrap_or(0);
-        assert_eq!(rebuild_after_noop, 1, "rebuild_chunks must NOT be called on no-op sync (issue #203 regression)");
+        assert!(
+            grid.pathfind_costs[wall_idx] == 0,
+            "wall cell must be impassable after no-op sync"
+        );
+        let rebuild_after_noop = grid
+            .hpa_cache
+            .as_ref()
+            .map(|c| c.rebuild_count)
+            .unwrap_or(0);
+        assert_eq!(
+            rebuild_after_noop, 1,
+            "rebuild_chunks must NOT be called on no-op sync (issue #203 regression)"
+        );
 
         let empty_map = EntityMap::default();
         grid.sync_building_costs(&empty_map);
-        assert!(grid.dirty_cost_cells().is_empty(), "no building cells after wall removed");
-        assert!(grid.pathfind_costs[wall_idx] > 0, "wall cell passable after removal");
-        let rebuild_after_remove = grid.hpa_cache.as_ref().map(|c| c.rebuild_count).unwrap_or(0);
-        assert_eq!(rebuild_after_remove, 2, "rebuild_chunks called once more on wall removal");
+        assert!(
+            grid.dirty_cost_cells().is_empty(),
+            "no building cells after wall removed"
+        );
+        assert!(
+            grid.pathfind_costs[wall_idx] > 0,
+            "wall cell passable after removal"
+        );
+        let rebuild_after_remove = grid
+            .hpa_cache
+            .as_ref()
+            .map(|c| c.rebuild_count)
+            .unwrap_or(0);
+        assert_eq!(
+            rebuild_after_remove, 2,
+            "rebuild_chunks called once more on wall removal"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #168

## Change

Replace the hardcoded `iter_kind` chain in `building_tower_system` (`combat.rs:866-869`) with a registry-based filter using `iter_instances()`:

**Before:**
\`\`\`rust
entity_map
    .iter_kind(BuildingKind::BowTower)
    .chain(entity_map.iter_kind(BuildingKind::CrossbowTower))
    .chain(entity_map.iter_kind(BuildingKind::CatapultTower))
    .chain(entity_map.iter_kind(BuildingKind::GuardTower))
\`\`\`

**After:**
\`\`\`rust
entity_map
    .iter_instances()
    .filter(|i| {
        let def = crate::constants::building_def(i.kind);
        def.is_tower && i.kind != BuildingKind::Fountain
    })
\`\`\`

This matches the existing pattern 16 lines above (the `retain` call) and satisfies k8s.md: adding a new tower kind now requires only 1 enum variant + 1 registry entry.

## Tests

- `tower_collection_uses_registry_is_tower_filter`: verifies registry-based filter returns exactly all `is_tower` buildings (excluding Fountain), and excludes non-tower buildings
- All 20 existing `systems::combat` tests pass