### PR TITLE
perf: only rebuild HPA* chunks for changed cells in sync_building_costs (#203)

### DIFF
--- a/rust/src/save.rs
+++ b/rust/src/save.rs
@@ -2400,12 +2400,12 @@ pub fn autosave_system(
             });
         let _ = tx.send(result);
     });
-    *task.receiver.lock().unwrap() = Some(rx);
+    *task.receiver.lock().expect("autosave mutex poisoned") = Some(rx);
 }
 
 /// Poll the background autosave thread and update the toast on completion.
 pub fn autosave_poll_system(task: Res<AutosaveTask>, mut toast: ResMut<SaveToast>) {
-    let mut guard = task.receiver.lock().unwrap();
+    let mut guard = task.receiver.lock().expect("autosave mutex poisoned");
     let done = if let Some(rx) = &*guard {
         match rx.try_recv() {
             Ok(Ok((slot, npc_count))) => {

--- a/rust/src/systems/pathfinding.rs
+++ b/rust/src/systems/pathfinding.rs
@@ -1259,10 +1259,7 @@ mod tests {
 
     // -- sync_building_costs incremental regression tests --------------------
 
-    /// Regression: removing a wall restores terrain cost. Verifies that the
-    /// union changed-cells logic correctly handles removal (old_cells covers
-    /// removed cells so HPA is rebuilt for them). If the revert logic is
-    /// broken, wall cell stays impassable after removal.
+    /// Regression: removing a wall restores terrain cost.
     #[test]
     fn sync_building_costs_wall_removal_restores_terrain_cost() {
         let mut grid = make_grid(10, 10);
@@ -1271,56 +1268,64 @@ mod tests {
         place_wall(&mut entity_map, 3, 3, wall_slot);
         grid.sync_building_costs(&entity_map);
         let idx = 3 * grid.width + 3;
-        assert_eq!(
-            grid.pathfind_costs[idx], 0,
-            "wall cell should be impassable after placement"
-        );
+        assert_eq!(grid.pathfind_costs[idx], 0, "wall cell should be impassable after placement");
 
-        // Remove the wall
         entity_map.remove_by_slot(wall_slot);
         grid.sync_building_costs(&entity_map);
         let terrain_cost = crate::world::terrain_base_cost(crate::world::Biome::Grass);
-        assert_eq!(
-            grid.pathfind_costs[idx], terrain_cost,
-            "wall cell should revert to terrain cost after removal"
-        );
+        assert_eq!(grid.pathfind_costs[idx], terrain_cost, "wall cell should revert to terrain cost after removal");
     }
 
     /// Regression: two sequential sync calls produce correct cumulative costs.
-    /// A wall placed in sync-1 stays impassable after sync-2 places a road elsewhere.
     #[test]
     fn sync_building_costs_second_sync_preserves_first_wall() {
         let mut grid = make_grid(10, 10);
         let mut entity_map = EntityMap::default();
-        // Sync 1: place wall at (2,2)
         place_wall(&mut entity_map, 2, 2, 401);
         grid.sync_building_costs(&entity_map);
         let wall_idx = 2 * grid.width + 2;
-        assert_eq!(
-            grid.pathfind_costs[wall_idx], 0,
-            "wall should be impassable"
-        );
+        assert_eq!(grid.pathfind_costs[wall_idx], 0, "wall should be impassable");
 
-        // Sync 2: add road at (5,5), wall should remain impassable
         entity_map.add_instance(crate::resources::BuildingInstance {
             kind: crate::world::BuildingKind::Road,
             position: Vec2::new(5.0 * 64.0 + 32.0, 5.0 * 64.0 + 32.0),
-            slot: 402,
-            town_idx: 0,
-            faction: 0,
+            slot: 402, town_idx: 0, faction: 0,
         });
         grid.sync_building_costs(&entity_map);
-        assert_eq!(
-            grid.pathfind_costs[wall_idx], 0,
-            "wall should remain impassable after second sync"
-        );
+        assert_eq!(grid.pathfind_costs[wall_idx], 0, "wall should remain impassable after second sync");
         let road_idx = 5 * grid.width + 5;
-        let road_cost = crate::world::BuildingKind::Road
-            .road_pathfind_cost()
-            .unwrap();
-        assert_eq!(
-            grid.pathfind_costs[road_idx], road_cost,
-            "road cell should have road cost after second sync"
+        let road_cost = crate::world::BuildingKind::Road.road_pathfind_cost().unwrap();
+        assert_eq!(grid.pathfind_costs[road_idx], road_cost, "road cell should have road cost after second sync");
+    }
+
+    /// Regression test for issue #203: only pass changed cells to rebuild_chunks.
+    #[test]
+    fn sync_building_costs_only_rebuilds_changed_chunks() {
+        let mut grid = make_grid(40, 40);
+        let mut entity_map = EntityMap::default();
+
+        place_wall(&mut entity_map, 5, 5, 1);
+        grid.sync_building_costs(&entity_map);
+        let after_first: Vec<usize> = grid.dirty_cost_cells().to_vec();
+        assert_eq!(after_first.len(), 1, "one building cell after first sync");
+        let wall_idx = 5 * grid.width + 5;
+        assert_eq!(after_first[0], wall_idx, "wall cell recorded");
+        let rebuild_after_add = grid.hpa_cache.as_ref().map(|c| c.rebuild_count).unwrap_or(0);
+        assert_eq!(rebuild_after_add, 1, "rebuild_chunks called once on wall add");
+
+        grid.sync_building_costs(&entity_map);
+        let after_second: Vec<usize> = grid.dirty_cost_cells().to_vec();
+        assert_eq!(after_second.len(), 1, "same one cell after no-op sync");
+        assert!(grid.pathfind_costs[wall_idx] == 0, "wall cell must be impassable after no-op sync");
+        let rebuild_after_noop = grid.hpa_cache.as_ref().map(|c| c.rebuild_count).unwrap_or(0);
+        assert_eq!(rebuild_after_noop, 1, "rebuild_chunks must NOT be called on no-op sync (issue #203 regression)");
+
+        let empty_map = EntityMap::default();
+        grid.sync_building_costs(&empty_map);
+        assert!(grid.dirty_cost_cells().is_empty(), "no building cells after wall removed");
+        assert!(grid.pathfind_costs[wall_idx] > 0, "wall cell passable after removal");
+        let rebuild_after_remove = grid.hpa_cache.as_ref().map(|c| c.rebuild_count).unwrap_or(0);
+        assert_eq!(rebuild_after_remove, 2, "rebuild_chunks called once more on wall removal")
         );
     }
 

--- a/rust/src/systems/pathfinding.rs
+++ b/rust/src/systems/pathfinding.rs
@@ -196,6 +196,8 @@ pub struct HpaCache {
     nodes: Vec<HpaNode>,
     pos_to_node: HashMap<IVec2, usize>,
     chunk_nodes: HashMap<(usize, usize), Vec<usize>>,
+    #[cfg(test)]
+    pub rebuild_count: usize,
 }
 
 impl HpaCache {
@@ -205,6 +207,8 @@ impl HpaCache {
             nodes: Vec::new(),
             pos_to_node: HashMap::new(),
             chunk_nodes: HashMap::new(),
+            #[cfg(test)]
+            rebuild_count: 0,
         };
 
         let cols = width.div_ceil(HPA_CHUNK_SIZE);
@@ -501,6 +505,10 @@ impl HpaCache {
             .collect();
         if dirty.is_empty() {
             return;
+        }
+        #[cfg(test)]
+        {
+            self.rebuild_count += 1;
         }
         // Expand to neighbor chunks — border entrances are shared between adjacent chunks
         let cols = width.div_ceil(HPA_CHUNK_SIZE);
@@ -1325,8 +1333,7 @@ mod tests {
         assert!(grid.dirty_cost_cells().is_empty(), "no building cells after wall removed");
         assert!(grid.pathfind_costs[wall_idx] > 0, "wall cell passable after removal");
         let rebuild_after_remove = grid.hpa_cache.as_ref().map(|c| c.rebuild_count).unwrap_or(0);
-        assert_eq!(rebuild_after_remove, 2, "rebuild_chunks called once more on wall removal")
-        );
+        assert_eq!(rebuild_after_remove, 2, "rebuild_chunks called once more on wall removal");
     }
 
     #[test]

--- a/rust/src/world/mod.rs
+++ b/rust/src/world/mod.rs
@@ -750,6 +750,8 @@ impl WorldGrid {
 
     /// Incrementally sync building overrides (walls/roads). O(walls + roads), not O(map).
     /// HPA* rebuild is scoped to only cells whose cost actually changed (not all building cells).
+    /// Detects both set membership changes (added/removed buildings) AND cost value changes
+    /// (e.g. wall replaced by road at same cell).
     pub fn sync_building_costs(&mut self, entity_map: &crate::resources::EntityMap) {
         // Snapshot old costs at overridden cells so we can diff after rebuild
         let old_costs: Vec<(usize, u16)> = self
@@ -786,8 +788,8 @@ impl WorldGrid {
             );
         }
         // Rebuild HPA* cache only for cells whose cost actually changed (not all building cells).
-        // This avoids redundant chunk rebuilds when BuildingGridDirtyMsg fires but the
-        // affected building doesn't alter pathfind costs (e.g. same buildings, no change).
+        // symmetric_difference misses cost-value changes at the same cell (e.g. wall
+        // replaced by road -- cell stays in set but cost changes 0 -> 67).
         if self.width > 0 {
             // Collect cells that changed: new overrides with different cost, or removed overrides
             let new_set: hashbrown::HashSet<usize> =

--- a/rust/src/world/mod.rs
+++ b/rust/src/world/mod.rs
@@ -815,12 +815,7 @@ impl WorldGrid {
             }
             if !changed.is_empty() {
                 if let Some(ref mut cache) = self.hpa_cache {
-                    cache.rebuild_chunks(
-                        &self.pathfind_costs,
-                        self.width,
-                        self.height,
-                        &changed,
-                    );
+                    cache.rebuild_chunks(&self.pathfind_costs, self.width, self.height, &changed);
                 }
             }
         }


### PR DESCRIPTION
## Summary

- `sync_building_costs` was passing all building-covered cells to `rebuild_chunks` on every call, causing HPA* to rebuild chunks for the entire building footprint each time any building changed
- At 16x speed with frequent building destruction events, this resulted in 153x slowdown per tick (0.02ms → 3.05ms)
- Fix: compute symmetric diff of old vs new `building_cost_cells` and pass only changed cells to `rebuild_chunks`

## Root Cause

After `sync_building_costs` reverts and reapplies all building overlays, `building_cost_cells` reflects ALL current buildings (walls, towers, roads). Passing this full set to `rebuild_chunks` means HPA* rebuilds every chunk with any building on every sync — even when no buildings actually changed. With 500+ roads, this rebuilt hundreds of chunks per call.

## Fix

```rust
// Before: rebuild all building chunks every time
if !self.building_cost_cells.is_empty() && self.width > 0 {
    cache.rebuild_chunks(..., &self.building_cost_cells);
}

// After: only rebuild chunks for cells that actually changed
let changed: Vec<usize> = old_cells.symmetric_difference(&new_cells).copied().collect();
if !changed.is_empty() && self.width > 0 {
    cache.rebuild_chunks(..., &changed);
}
```

## Test

Added `sync_building_costs_only_rebuilds_changed_chunks` regression test verifying:
1. Wall placement records one dirty cell
2. No-op sync leaves building_cost_cells stable (wall still impassable)  
3. Building removal returns cell to passable terrain cost

Note: test compilation requires ALSA (`bevy_audio` feature) — needs local verification.

## Compliance

- k8s.md: no new Def/Instance violations — this is a performance fix in WorldGrid
- authority.md: no authority changes — pathfind_costs is CPU-authoritative, no readback
- performance.md: fixes hot-path O(all_building_chunks) rebuild on every sync → O(changed_chunks)