### PR TITLE
perf: replace mason iter_instances with for_each_nearby spatial query

### DIFF
--- a/rust/benches/system_bench.rs
+++ b/rust/benches/system_bench.rs
@@ -16,8 +16,8 @@ use endless::gpu::populate_gpu_state;
 use endless::gpu::{EntityGpuState, ProjBufferWrites};
 use endless::messages::*;
 use endless::resources::*;
-use endless::systems::stats;
 use endless::systems::ai_player::{AiSnapshotDirty, RoadStyle};
+use endless::systems::stats;
 use endless::systems::{
     AiKind, AiPersonality, AiPlayer, AiPlayerConfig, AiPlayerState, advance_waypoints_system,
     ai_decision_system, arrival_system, attack_system, building_tower_system,

--- a/rust/src/systems/decision/mod.rs
+++ b/rust/src/systems/decision/mod.rs
@@ -2207,30 +2207,35 @@ pub fn decision_system(
                     );
                     break 'decide;
                 }
-                // Find nearest damaged building at current position
+                // Find nearest damaged building at current position (spatial query)
                 let current_pos = npc_pos.unwrap_or(home);
-                let repair_radius_sq: f32 = 40.0 * 40.0;
+                let repair_radius: f32 = 40.0;
+                let repair_radius_sq = repair_radius * repair_radius;
                 let mut repaired = false;
-                for inst in entity_map.iter_instances() {
+                entity_map.for_each_nearby(current_pos, repair_radius, |inst, _occ| {
+                    if repaired {
+                        return;
+                    }
                     if inst.town_idx != town_idx_i32 as u32 {
-                        continue;
+                        return;
                     }
                     if inst.position.distance_squared(current_pos) > repair_radius_sq {
-                        continue;
+                        return;
                     }
                     let Some(bld_entity) = entity_map.entities.get(&inst.slot).copied() else {
-                        continue;
+                        return;
                     };
                     let Ok(mut bld_hp) = building_health_q.get_mut(bld_entity) else {
-                        continue;
+                        return;
                     };
                     let max_hp = crate::constants::building_def(inst.kind).hp;
                     if bld_hp.0 >= max_hp {
-                        continue;
+                        return;
                     }
                     bld_hp.0 = (bld_hp.0 + MASON_REPAIR_RATE).min(max_hp);
                     repaired = true;
                     if bld_hp.0 >= max_hp {
+                        let kind = inst.kind;
                         if npc_logs.should_log(idx) {
                             npc_logs.push(
                                 idx,
@@ -2239,13 +2244,12 @@ pub fn decision_system(
                                 game_time.minute(),
                                 format!(
                                     "Repaired {} to full HP",
-                                    crate::constants::building_def(inst.kind).label
+                                    crate::constants::building_def(kind).label
                                 ),
                             );
                         }
                     }
-                    break; // repair one building per tick
-                }
+                });
                 if !repaired {
                     // No damaged building nearby -- go idle
                     transition_activity(
@@ -2842,29 +2846,34 @@ pub fn decision_system(
                             let current_pos = npc_pos.unwrap_or(home);
                             let max_dist_sq = MASON_SEARCH_RADIUS * MASON_SEARCH_RADIUS;
                             let mut best: Option<(f32, Vec2)> = None;
-                            for inst in entity_map.iter_instances() {
-                                if inst.town_idx != town_idx_i32 as u32 {
-                                    continue;
-                                }
-                                let dist_sq = inst.position.distance_squared(current_pos);
-                                if dist_sq > max_dist_sq {
-                                    continue;
-                                }
-                                let Some(bld_entity) = entity_map.entities.get(&inst.slot).copied()
-                                else {
-                                    continue;
-                                };
-                                let Ok(bld_hp) = building_health_q.get(bld_entity) else {
-                                    continue;
-                                };
-                                let max_hp = crate::constants::building_def(inst.kind).hp;
-                                if bld_hp.0 >= max_hp {
-                                    continue;
-                                }
-                                if best.as_ref().is_none_or(|b| dist_sq < b.0) {
-                                    best = Some((dist_sq, inst.position));
-                                }
-                            }
+                            entity_map.for_each_nearby(
+                                current_pos,
+                                MASON_SEARCH_RADIUS,
+                                |inst, _occ| {
+                                    if inst.town_idx != town_idx_i32 as u32 {
+                                        return;
+                                    }
+                                    let dist_sq = inst.position.distance_squared(current_pos);
+                                    if dist_sq > max_dist_sq {
+                                        return;
+                                    }
+                                    let Some(bld_entity) =
+                                        entity_map.entities.get(&inst.slot).copied()
+                                    else {
+                                        return;
+                                    };
+                                    let Ok(bld_hp) = building_health_q.get(bld_entity) else {
+                                        return;
+                                    };
+                                    let max_hp = crate::constants::building_def(inst.kind).hp;
+                                    if bld_hp.0 >= max_hp {
+                                        return;
+                                    }
+                                    if best.as_ref().is_none_or(|b| dist_sq < b.0) {
+                                        best = Some((dist_sq, inst.position));
+                                    }
+                                },
+                            );
                             if let Some((_, target_pos)) = best {
                                 transition_activity(
                                     &mut activity,

--- a/rust/src/systems/decision/tests.rs
+++ b/rust/src/systems/decision/tests.rs
@@ -1036,6 +1036,11 @@ fn setup_mason_app(buildings: Vec<(BuildingKind, Vec2, f32)>) -> (App, Entity) {
     let policy = PolicySet::default();
     let mut app = setup_decision_app(policy);
 
+    // Initialize spatial grid so for_each_nearby works in tests
+    app.world_mut()
+        .resource_mut::<EntityMap>()
+        .init_spatial(16384.0);
+
     // Register buildings in EntityMap and spawn ECS entities with Health + Building
     let mut slot = 1000; // high slot to avoid collision with NPC slots
     for (kind, pos, hp) in &buildings {
@@ -1160,5 +1165,53 @@ fn mason_repair_increments_health_caps_at_max() {
     assert!(
         (hp2 - max_hp).abs() < f32::EPSILON,
         "should cap at max HP when rate exceeds deficit"
+    );
+}
+
+#[test]
+fn mason_repairs_nearby_damaged_building_in_active_state() {
+    // Regression test for FINDING-3: the Repair/Active scan uses for_each_nearby
+    // (spatial query) instead of iter_instances (O(all_buildings)).
+    // If for_each_nearby is reverted without init_spatial, no buildings are found
+    // and hp_after == hp_before, failing this assertion.
+    use crate::constants::MASON_REPAIR_RATE;
+
+    let farm_max_hp = crate::constants::building_def(BuildingKind::Farm).hp;
+    let initial_hp = farm_max_hp - 10.0;
+    // Mason NPC is at slot 0, GpuReadState positions = [64, 64] (setup_decision_app default)
+    let bld_pos = Vec2::new(64.0, 64.0); // within 40px repair radius of mason
+
+    let (mut app, mason) = setup_mason_app(vec![(BuildingKind::Farm, bld_pos, initial_hp)]);
+
+    // Put mason in Repair/Active -- triggers the spatial repair-at-site loop
+    {
+        let mut activity = app.world_mut().get_mut::<Activity>(mason).unwrap();
+        activity.kind = ActivityKind::Repair;
+        activity.phase = ActivityPhase::Active;
+    }
+
+    let bld_entity = {
+        let em = app.world().resource::<EntityMap>();
+        *em.entities
+            .get(&1000)
+            .expect("building slot 1000 must exist")
+    };
+
+    let hp_before = app.world().get::<Health>(bld_entity).unwrap().0;
+    app.world_mut().run_system_once(decision_system).unwrap();
+    let hp_after = app.world().get::<Health>(bld_entity).unwrap().0;
+
+    assert!(
+        hp_after > hp_before,
+        "mason in Repair/Active must repair the nearby building via spatial query: before={hp_before}, after={hp_after}"
+    );
+    assert!(
+        hp_after <= farm_max_hp,
+        "repaired hp must not exceed max: hp_after={hp_after}, max={farm_max_hp}"
+    );
+    let expected = (initial_hp + MASON_REPAIR_RATE).min(farm_max_hp);
+    assert!(
+        (hp_after - expected).abs() < f32::EPSILON,
+        "hp should increase by exactly MASON_REPAIR_RATE: expected={expected}, got={hp_after}"
     );
 }


### PR DESCRIPTION
## Summary

- Replaces O(all_buildings) `iter_instances()` scans in both Mason decision sites with O(buildings_in_radius) `for_each_nearby()` spatial queries
- FINDING-3 (repair-at-site, 40px radius): replaced with `for_each_nearby` + `repaired` flag for early-exit behavior
- FINDING-4 (idle work-target search, MASON_SEARCH_RADIUS): replaced with `for_each_nearby`
- Both sites use the pattern established in `squad_commander.rs` (double immutable borrow of `entity_map` is safe; `building_health_q` is a separate resource)
- Updated `setup_mason_app` in tests to call `init_spatial(16384.0)` so spatial queries work correctly in all existing Mason tests
- Added regression test `mason_repairs_nearby_damaged_building_in_active_state` that fails if `for_each_nearby` is reverted without spatial init

## Test plan

- [x] `cargo test --lib -- decision`: 41 tests pass
- [x] `cargo test --lib -- world`: 12 tests pass
- [x] `cargo clippy --release -- -D warnings`: clean
- [x] New regression test `mason_repairs_nearby_damaged_building_in_active_state` verifies building HP increases after mason tick
- [x] Compliance verified: no k8s.md violations (no Def fields cached on instances), no authority.md violations (Health stays CPU-authoritative), no performance.md violations (O(n) iter replaced with O(k) spatial)