### PR TITLE
perf: skip full spatial rebuild on subsequent BuildingGridDirtyMsg

### DIFF
--- a/rust/benches/system_bench.rs
+++ b/rust/benches/system_bench.rs
@@ -16,8 +16,8 @@ use endless::gpu::populate_gpu_state;
 use endless::gpu::{EntityGpuState, ProjBufferWrites};
 use endless::messages::*;
 use endless::resources::*;
-use endless::systems::stats;
 use endless::systems::ai_player::{AiSnapshotDirty, RoadStyle};
+use endless::systems::stats;
 use endless::systems::{
     AiKind, AiPersonality, AiPlayer, AiPlayerConfig, AiPlayerState, advance_waypoints_system,
     ai_decision_system, arrival_system, attack_system, building_tower_system,

--- a/rust/src/entity_map.rs
+++ b/rust/src/entity_map.rs
@@ -613,6 +613,11 @@ impl EntityMap {
         self.spatial_cells.resize_with(total, Vec::new);
     }
 
+    /// Returns true if init_spatial has been called and the grid is ready for queries.
+    pub fn is_spatial_initialized(&self) -> bool {
+        self.spatial_width > 0
+    }
+
     pub fn rebuild_spatial(&mut self) {
         for cell in &mut self.spatial_cells {
             cell.clear();

--- a/rust/src/world/mod.rs
+++ b/rust/src/world/mod.rs
@@ -557,6 +557,10 @@ impl BuildingKind {
 }
 
 /// Rebuild building spatial grid. Only runs when BuildingGridDirtyMsg is received.
+/// On first run (spatial uninitialized), performs a full rebuild to populate from
+/// any buildings placed before init_spatial was called. On subsequent runs, the
+/// spatial grid is already maintained incrementally by add_instance/remove_instance,
+/// so only init_spatial (idempotent) is called -- O(1) per building change.
 pub fn rebuild_building_grid_system(
     mut entity_map: ResMut<EntityMap>,
     mut grid_dirty: MessageReader<BuildingGridDirtyMsg>,
@@ -565,9 +569,12 @@ pub fn rebuild_building_grid_system(
     if grid.width == 0 || grid_dirty.read().count() == 0 {
         return;
     }
+    let needs_full_rebuild = !entity_map.is_spatial_initialized();
     let world_size_px = grid.width as f32 * grid.cell_size;
     entity_map.init_spatial(world_size_px);
-    entity_map.rebuild_spatial();
+    if needs_full_rebuild {
+        entity_map.rebuild_spatial();
+    }
 }
 
 // ============================================================================

--- a/rust/src/world/tests.rs
+++ b/rust/src/world/tests.rs
@@ -133,6 +133,56 @@ fn rebuild_building_grid_preserves_spatial_on_subsequent_frame() {
 }
 
 #[test]
+fn building_added_after_init_findable_without_dirty_message() {
+    // After spatial init, add_instance must insert directly into the spatial grid.
+    // No second dirty message should be required for the new building to be found.
+    // This verifies the incremental O(1) path: add_instance -> spatial_insert inline.
+    // If this test fails, the incremental spatial update path is broken and full
+    // O(n) rebuilds would be needed on every building change again.
+    let mut app = setup_rebuild_app();
+
+    // Initialize spatial via the first dirty message
+    let pos_a = Vec2::new(32.0, 32.0);
+    app.world_mut()
+        .resource_mut::<EntityMap>()
+        .add_instance(BuildingInstance {
+            kind: BuildingKind::Farm,
+            position: pos_a,
+            slot: 1,
+            town_idx: 0,
+            faction: 1,
+        });
+    app.insert_resource(SendBuildingGridDirty(true));
+    app.update();
+    assert!(
+        app.world().resource::<EntityMap>().is_spatial_initialized(),
+        "spatial should be initialized after first dirty message"
+    );
+
+    // Add a second building WITHOUT sending a dirty message
+    let pos_b = Vec2::new(256.0, 256.0);
+    app.world_mut()
+        .resource_mut::<EntityMap>()
+        .add_instance(BuildingInstance {
+            kind: BuildingKind::Fountain,
+            position: pos_b,
+            slot: 2,
+            town_idx: 0,
+            faction: 1,
+        });
+    app.update();
+
+    // The new building must be findable -- add_instance calls spatial_insert inline
+    let em = app.world().resource::<EntityMap>();
+    let mut found = false;
+    em.for_each_nearby(pos_b, 200.0, |_, _| found = true);
+    assert!(
+        found,
+        "building added after init must be findable without a dirty message"
+    );
+}
+
+#[test]
 fn road_blocked_on_forest_biome() {
     let mut app = App::new();
     app.add_plugins(MinimalPlugins);


### PR DESCRIPTION
## Problem

`rebuild_building_grid_system` does a full O(n) spatial rebuild on every `BuildingGridDirtyMsg`. At 16x speed with frequent building changes, this costs 3.65ms/tick (122x increase from 1x).

## Root Cause

`EntityMap.add_instance` and `remove_instance` already call `spatial_insert`/`spatial_remove` inline, keeping the spatial grid up-to-date incrementally. The full `rebuild_spatial()` call in `rebuild_building_grid_system` was redundant after the initial setup.

The full rebuild was only needed once: on first startup when `spatial_width == 0` and buildings were placed before `init_spatial` was called.

## Fix

- Add `is_spatial_initialized()` to `EntityMap`
- In `rebuild_building_grid_system`: only call `rebuild_spatial()` when `spatial_width == 0` (first init). Subsequent calls skip the O(n) rebuild entirely -- the grid is already correct via incremental updates.

## Result

- First `BuildingGridDirtyMsg`: O(n) full rebuild (once, on startup)
- Subsequent messages: O(1) -- just `init_spatial` (idempotent no-op)

## Compliance

- k8s.md: no change to Def/Instance/Controller pattern
- authority.md: no change to data ownership
- performance.md: eliminates O(n) rebuild on every building change, matches "event-driven updates" pattern

## Tests

- All 12 existing `world::tests` pass
- New regression test: `building_added_after_init_findable_without_dirty_message` -- verifies that `add_instance` after init inserts directly into spatial grid without requiring a rebuild message. Would FAIL if `spatial_insert` was removed from `add_instance`.

Closes #202