### PR TITLE
perf: replace mason iter_instances with for_each_nearby spatial query (#169)

### DIFF
--- a/rust/benches/system_bench.rs
+++ b/rust/benches/system_bench.rs
@@ -1971,6 +1971,239 @@ fn bench_farm_visual_system(c: &mut Criterion) {
     group.finish();
 }
 
+// ── Mason decision building-scale benchmark (issue-169 spatial query validation) ──────────────
+
+/// Building counts to exercise mason O(buildings_in_radius) vs prior O(all_buildings).
+const MASON_BUILDING_COUNTS: &[usize] = &[1_000, 10_000, 50_000];
+
+/// World size large enough that only ~12% of buildings fall within the mason's
+/// 6400px search radius, proving O(buildings_in_radius) at each scale.
+const MASON_WORLD_SIZE: f32 = 32768.0;
+const MASON_POS: Vec2 = Vec2::new(16384.0, 16384.0);
+
+/// Set up bench app with 1 Mason NPC and `building_count` buildings spread across a 32768px world.
+/// The mason is at the world center; buildings are spread evenly across the full map.
+/// Only ~12% of buildings fall within MASON_SEARCH_RADIUS (6400px).
+fn populate_mason_scale_bench(app: &mut App, building_count: usize) {
+    // World grid (512 x 512 cells at 64px spacing = 32768px world)
+    {
+        let mut grid = app.world_mut().resource_mut::<world::WorldGrid>();
+        grid.width = 512;
+        grid.height = 512;
+        grid.cell_size = TOWN_GRID_SPACING;
+        grid.cells = vec![world::WorldCell::default(); 512 * 512];
+    }
+    {
+        let mut wd = app.world_mut().resource_mut::<world::WorldData>();
+        wd.towns.push(world::Town {
+            name: "BenchTown".into(),
+            center: MASON_POS,
+            faction: 1,
+            kind: TownKind::Player,
+        });
+    }
+    {
+        let mut fl = app.world_mut().resource_mut::<FactionList>();
+        fl.factions.push(FactionData {
+            kind: FactionKind::Neutral,
+            name: "Neutral".into(),
+            towns: vec![],
+        });
+        fl.factions.push(FactionData {
+            kind: FactionKind::Player,
+            name: "Player".into(),
+            towns: vec![0],
+        });
+    }
+
+    // Init spatial grid over the full world
+    app.world_mut()
+        .resource_mut::<EntityMap>()
+        .init_spatial(MASON_WORLD_SIZE);
+
+    // Force all NPCs to process every tick (disable adaptive bucketing)
+    {
+        let mut cfg = app.world_mut().resource_mut::<NpcDecisionConfig>();
+        cfg.interval = 0.0;
+        cfg.max_decisions_per_frame = 1_000_000;
+    }
+
+    // Allocate GPU slot for the mason
+    const MASON_SLOT: usize = 0;
+    let _ = app.world_mut().resource_mut::<GpuSlotPool>().alloc_reset(); // consumes slot 0
+
+    // Spawn the mason NPC at world center
+    let mason_entity = app
+        .world_mut()
+        .spawn((
+            (
+                GpuSlot(MASON_SLOT),
+                Position {
+                    x: MASON_POS.x,
+                    y: MASON_POS.y,
+                },
+                Health(80.0),
+                Job::Mason,
+                Faction(1),
+                TownId(0),
+                Activity {
+                    kind: ActivityKind::Idle,
+                    phase: ActivityPhase::Ready,
+                    target: ActivityTarget::None,
+                    ..Default::default()
+                },
+                CombatState::default(),
+                Energy(100.0),
+                Speed(60.0),
+                Home(MASON_POS),
+                NpcFlags {
+                    at_destination: true,
+                    ..Default::default()
+                },
+            ),
+            (
+                CachedStats {
+                    damage: 10.0,
+                    range: 40.0,
+                    cooldown: 1.0,
+                    projectile_speed: 0.0,
+                    projectile_lifetime: 0.0,
+                    max_health: 100.0,
+                    speed: 60.0,
+                    stamina: 1.0,
+                    hp_regen: 0.0,
+                    berserk_bonus: 0.0,
+                },
+                BaseAttackType::Melee,
+                AttackTimer(0.0),
+                NpcWorkState::default(),
+                PatrolRoute {
+                    posts: vec![],
+                    current: 0,
+                },
+                CarriedLoot {
+                    food: 0,
+                    gold: 0,
+                    wood: 0,
+                    stone: 0,
+                    equipment: vec![],
+                },
+                Personality::default(),
+                FleeThreshold { pct: 0.2 },
+                LeashRange(400.0),
+                WoundedThreshold { pct: 0.3 },
+                HasEnergy,
+                NpcEquipment::default(),
+                SquadId(0),
+                NpcPath::default(),
+            ),
+        ))
+        .id();
+
+    // Register mason in EntityMap and populate GPU readback state
+    {
+        let mut em = app.world_mut().resource_mut::<EntityMap>();
+        em.register_npc(MASON_SLOT, mason_entity, Job::Mason, 1, 0);
+    }
+    {
+        let mut gpu_read = app.world_mut().resource_mut::<GpuReadState>();
+        gpu_read.positions.resize(2, 0.0);
+        gpu_read.combat_targets.resize(1, -1);
+        gpu_read.health.resize(1, 1.0);
+        gpu_read.factions.resize(1, 1);
+        gpu_read.threat_counts.resize(1, 0);
+        gpu_read.npc_count = 1;
+        gpu_read.positions[MASON_SLOT * 2] = MASON_POS.x;
+        gpu_read.positions[MASON_SLOT * 2 + 1] = MASON_POS.y;
+    }
+    {
+        let mut gpu_state = app.world_mut().resource_mut::<EntityGpuState>();
+        gpu_state.positions.resize(2, 0.0);
+        gpu_state.factions.resize(1, 1);
+        gpu_state.healths.resize(1, 1.0);
+        gpu_state.max_healths.resize(1, 100.0);
+        gpu_state.speeds.resize(1, 60.0);
+        gpu_state.positions[MASON_SLOT * 2] = MASON_POS.x;
+        gpu_state.positions[MASON_SLOT * 2 + 1] = MASON_POS.y;
+    }
+
+    // Spawn buildings spread evenly across the full world map.
+    // Buildings within MASON_SEARCH_RADIUS of the mason are damaged so the
+    // spatial scan has work to do; the rest are at full HP (spatial cells outside
+    // the radius are never visited under the new for_each_nearby path).
+    let cols = (building_count as f32).sqrt().ceil() as usize;
+    let rows = (building_count + cols - 1) / cols;
+    let cell_w = MASON_WORLD_SIZE / cols as f32;
+    let cell_h = MASON_WORLD_SIZE / rows as f32;
+
+    let base_slot = 1_000usize;
+    let mut building_entities: Vec<(Entity, usize, f32, f32)> = Vec::with_capacity(building_count);
+
+    for i in 0..building_count {
+        let col = i % cols;
+        let row = i / cols;
+        let x = (col as f32 + 0.5) * cell_w;
+        let y = (row as f32 + 0.5) * cell_h;
+        let slot = base_slot + i;
+
+        // Damage buildings that are within search radius so the mason finds repair targets
+        let dist_sq = (x - MASON_POS.x).powi(2) + (y - MASON_POS.y).powi(2);
+        let hp = if dist_sq < MASON_SEARCH_RADIUS * MASON_SEARCH_RADIUS {
+            50.0
+        } else {
+            100.0
+        };
+        let entity = app
+            .world_mut()
+            .spawn((
+                Building {
+                    kind: world::BuildingKind::Farm,
+                },
+                Health(hp),
+                GpuSlot(slot),
+            ))
+            .id();
+        building_entities.push((entity, slot, x, y));
+    }
+
+    {
+        let mut em = app.world_mut().resource_mut::<EntityMap>();
+        for (entity, slot, x, y) in &building_entities {
+            em.set_entity(*slot, *entity);
+            em.add_instance(endless::entity_map::BuildingInstance {
+                kind: world::BuildingKind::Farm,
+                position: Vec2::new(*x, *y),
+                town_idx: 0,
+                slot: *slot,
+                faction: 1,
+            });
+        }
+    }
+}
+
+/// Benchmark mason decision at 1K / 10K / 50K buildings.
+/// Measures O(buildings_in_radius) spatial query cost vs the prior O(all_buildings) scan.
+/// At 50K buildings spread across a 32768px world, ~12% fall within the 6400px search
+/// radius, giving a ~8x improvement over the old iter_instances scan.
+fn bench_mason_decision_building_scale(c: &mut Criterion) {
+    let mut group = c.benchmark_group("mason_decision_building_scale");
+    group.sample_size(20);
+
+    for &count in MASON_BUILDING_COUNTS {
+        group.bench_with_input(BenchmarkId::from_parameter(count), &count, |b, &count| {
+            let mut app = build_bench_app();
+            spawn_bench_town(&mut app);
+            populate_mason_scale_bench(&mut app, count);
+            // Warmup: let the decision system run once to stabilize state
+            let _ = app.world_mut().run_system_once(decision_system);
+            b.iter(|| {
+                let _ = app.world_mut().run_system_once(decision_system);
+            });
+        });
+    }
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_decision_system,
@@ -2003,6 +2236,7 @@ criterion_group!(
     bench_build_building_body_instances,
     bench_resolve_work_targets,
     bench_ai_road_scoring,
+    bench_mason_decision_building_scale,
 );
 criterion_main!(benches);
 
@@ -2446,7 +2680,11 @@ fn bench_ai_road_scoring(c: &mut Criterion) {
                             let col = cc as i32 + dc;
                             let row = cr as i32 + dr;
                             if col >= 0 && row >= 0 {
-                                grid.add_town_buildable(col as usize, row as usize, town_idx as u16);
+                                grid.add_town_buildable(
+                                    col as usize,
+                                    row as usize,
+                                    town_idx as u16,
+                                );
                             }
                         }
                     }
@@ -2458,10 +2696,17 @@ fn bench_ai_road_scoring(c: &mut Criterion) {
                 for &(center, town_idx) in &town_centers {
                     let faction = (town_idx + 1) as i32;
                     for k in 0..8usize {
-                        let Some(slot) = pool.alloc_reset() else { break };
+                        let Some(slot) = pool.alloc_reset() else {
+                            break;
+                        };
                         let dx = (k % 4) as f32 * TOWN_GRID_SPACING - TOWN_GRID_SPACING * 1.5;
                         let dy = (k / 4) as f32 * TOWN_GRID_SPACING - TOWN_GRID_SPACING * 0.5;
-                        instances.push((slot, Vec2::new(center.x + dx, center.y + dy), town_idx as u32, faction));
+                        instances.push((
+                            slot,
+                            Vec2::new(center.x + dx, center.y + dy),
+                            town_idx as u32,
+                            faction,
+                        ));
                     }
                 }
                 instances
@@ -2469,7 +2714,11 @@ fn bench_ai_road_scoring(c: &mut Criterion) {
             let mut em = world.resource_mut::<EntityMap>();
             for (slot, pos, town_idx, faction) in farm_instances {
                 em.add_instance(endless::entity_map::BuildingInstance {
-                    kind: world::BuildingKind::Farm, position: pos, town_idx, slot, faction,
+                    kind: world::BuildingKind::Farm,
+                    position: pos,
+                    town_idx,
+                    slot,
+                    faction,
                 });
             }
         }
@@ -2478,7 +2727,11 @@ fn bench_ai_road_scoring(c: &mut Criterion) {
             let mut ai_state = world.resource_mut::<AiPlayerState>();
             for (i, p) in ai_state.players.iter_mut().enumerate() {
                 p.road_style = RoadStyle::Grid4;
-                p.decision_timer = if i == 0 { DEFAULT_AI_INTERVAL } else { i as f32 * DEFAULT_AI_INTERVAL / AI_TOWN_COUNT as f32 };
+                p.decision_timer = if i == 0 {
+                    DEFAULT_AI_INTERVAL
+                } else {
+                    i as f32 * DEFAULT_AI_INTERVAL / AI_TOWN_COUNT as f32
+                };
             }
         }
         let _ = app.world_mut().run_system_once(ai_decision_system);
@@ -2487,7 +2740,11 @@ fn bench_ai_road_scoring(c: &mut Criterion) {
                 let world = app.world_mut();
                 let mut ai_state = world.resource_mut::<AiPlayerState>();
                 for (i, p) in ai_state.players.iter_mut().enumerate() {
-                    p.decision_timer = if i == 0 { DEFAULT_AI_INTERVAL } else { i as f32 * DEFAULT_AI_INTERVAL / AI_TOWN_COUNT as f32 };
+                    p.decision_timer = if i == 0 {
+                        DEFAULT_AI_INTERVAL
+                    } else {
+                        i as f32 * DEFAULT_AI_INTERVAL / AI_TOWN_COUNT as f32
+                    };
                 }
             }
             let _ = app.world_mut().run_system_once(ai_decision_system);

--- a/rust/src/systems/decision/mod.rs
+++ b/rust/src/systems/decision/mod.rs
@@ -2223,30 +2223,35 @@ pub fn decision_system(
                     );
                     break 'decide;
                 }
-                // Find nearest damaged building at current position
+                // Find nearest damaged building at current position (spatial query)
                 let current_pos = npc_pos.unwrap_or(home);
-                let repair_radius_sq: f32 = 40.0 * 40.0;
+                let repair_radius: f32 = 40.0;
+                let repair_radius_sq = repair_radius * repair_radius;
                 let mut repaired = false;
-                for inst in entity_map.iter_instances() {
+                entity_map.for_each_nearby(current_pos, repair_radius, |inst, _occ| {
+                    if repaired {
+                        return;
+                    }
                     if inst.town_idx != town_idx_i32 as u32 {
-                        continue;
+                        return;
                     }
                     if inst.position.distance_squared(current_pos) > repair_radius_sq {
-                        continue;
+                        return;
                     }
                     let Some(bld_entity) = entity_map.entities.get(&inst.slot).copied() else {
-                        continue;
+                        return;
                     };
                     let Ok(mut bld_hp) = building_health_q.get_mut(bld_entity) else {
-                        continue;
+                        return;
                     };
                     let max_hp = crate::constants::building_def(inst.kind).hp;
                     if bld_hp.0 >= max_hp {
-                        continue;
+                        return;
                     }
                     bld_hp.0 = (bld_hp.0 + MASON_REPAIR_RATE).min(max_hp);
                     repaired = true;
                     if bld_hp.0 >= max_hp {
+                        let kind = inst.kind;
                         if npc_logs.should_log(idx) {
                             npc_logs.push(
                                 idx,
@@ -2255,13 +2260,12 @@ pub fn decision_system(
                                 game_time.minute(),
                                 format!(
                                     "Repaired {} to full HP",
-                                    crate::constants::building_def(inst.kind).label
+                                    crate::constants::building_def(kind).label
                                 ),
                             );
                         }
                     }
-                    break; // repair one building per tick
-                }
+                });
                 if !repaired {
                     // No damaged building nearby -- go idle
                     transition_activity(
@@ -2858,29 +2862,34 @@ pub fn decision_system(
                             let current_pos = npc_pos.unwrap_or(home);
                             let max_dist_sq = MASON_SEARCH_RADIUS * MASON_SEARCH_RADIUS;
                             let mut best: Option<(f32, Vec2)> = None;
-                            for inst in entity_map.iter_instances() {
-                                if inst.town_idx != town_idx_i32 as u32 {
-                                    continue;
-                                }
-                                let dist_sq = inst.position.distance_squared(current_pos);
-                                if dist_sq > max_dist_sq {
-                                    continue;
-                                }
-                                let Some(bld_entity) = entity_map.entities.get(&inst.slot).copied()
-                                else {
-                                    continue;
-                                };
-                                let Ok(bld_hp) = building_health_q.get(bld_entity) else {
-                                    continue;
-                                };
-                                let max_hp = crate::constants::building_def(inst.kind).hp;
-                                if bld_hp.0 >= max_hp {
-                                    continue;
-                                }
-                                if best.as_ref().is_none_or(|b| dist_sq < b.0) {
-                                    best = Some((dist_sq, inst.position));
-                                }
-                            }
+                            entity_map.for_each_nearby(
+                                current_pos,
+                                MASON_SEARCH_RADIUS,
+                                |inst, _occ| {
+                                    if inst.town_idx != town_idx_i32 as u32 {
+                                        return;
+                                    }
+                                    let dist_sq = inst.position.distance_squared(current_pos);
+                                    if dist_sq > max_dist_sq {
+                                        return;
+                                    }
+                                    let Some(bld_entity) =
+                                        entity_map.entities.get(&inst.slot).copied()
+                                    else {
+                                        return;
+                                    };
+                                    let Ok(bld_hp) = building_health_q.get(bld_entity) else {
+                                        return;
+                                    };
+                                    let max_hp = crate::constants::building_def(inst.kind).hp;
+                                    if bld_hp.0 >= max_hp {
+                                        return;
+                                    }
+                                    if best.as_ref().is_none_or(|b| dist_sq < b.0) {
+                                        best = Some((dist_sq, inst.position));
+                                    }
+                                },
+                            );
                             if let Some((_, target_pos)) = best {
                                 transition_activity(
                                     &mut activity,

--- a/rust/src/systems/decision/tests.rs
+++ b/rust/src/systems/decision/tests.rs
@@ -1037,6 +1037,11 @@ fn setup_mason_app(buildings: Vec<(BuildingKind, Vec2, f32)>) -> (App, Entity) {
     let policy = PolicySet::default();
     let mut app = setup_decision_app(policy);
 
+    // Initialize spatial grid so for_each_nearby works in tests
+    app.world_mut()
+        .resource_mut::<EntityMap>()
+        .init_spatial(16384.0);
+
     // Register buildings in EntityMap and spawn ECS entities with Health + Building
     let mut slot = 1000; // high slot to avoid collision with NPC slots
     for (kind, pos, hp) in &buildings {
@@ -1161,5 +1166,53 @@ fn mason_repair_increments_health_caps_at_max() {
     assert!(
         (hp2 - max_hp).abs() < f32::EPSILON,
         "should cap at max HP when rate exceeds deficit"
+    );
+}
+
+#[test]
+fn mason_repairs_nearby_damaged_building_in_active_state() {
+    // Regression test for FINDING-3: the Repair/Active scan uses for_each_nearby
+    // (spatial query) instead of iter_instances (O(all_buildings)).
+    // If for_each_nearby is reverted without init_spatial, no buildings are found
+    // and hp_after == hp_before, failing this assertion.
+    use crate::constants::MASON_REPAIR_RATE;
+
+    let farm_max_hp = crate::constants::building_def(BuildingKind::Farm).hp;
+    let initial_hp = farm_max_hp - 10.0;
+    // Mason NPC is at slot 0, GpuReadState positions = [64, 64] (setup_decision_app default)
+    let bld_pos = Vec2::new(64.0, 64.0); // within 40px repair radius of mason
+
+    let (mut app, mason) = setup_mason_app(vec![(BuildingKind::Farm, bld_pos, initial_hp)]);
+
+    // Put mason in Repair/Active -- triggers the spatial repair-at-site loop
+    {
+        let mut activity = app.world_mut().get_mut::<Activity>(mason).unwrap();
+        activity.kind = ActivityKind::Repair;
+        activity.phase = ActivityPhase::Active;
+    }
+
+    let bld_entity = {
+        let em = app.world().resource::<EntityMap>();
+        *em.entities
+            .get(&1000)
+            .expect("building slot 1000 must exist")
+    };
+
+    let hp_before = app.world().get::<Health>(bld_entity).unwrap().0;
+    app.world_mut().run_system_once(decision_system).unwrap();
+    let hp_after = app.world().get::<Health>(bld_entity).unwrap().0;
+
+    assert!(
+        hp_after > hp_before,
+        "mason in Repair/Active must repair the nearby building via spatial query: before={hp_before}, after={hp_after}"
+    );
+    assert!(
+        hp_after <= farm_max_hp,
+        "repaired hp must not exceed max: hp_after={hp_after}, max={farm_max_hp}"
+    );
+    let expected = (initial_hp + MASON_REPAIR_RATE).min(farm_max_hp);
+    assert!(
+        (hp_after - expected).abs() < f32::EPSILON,
+        "hp should increase by exactly MASON_REPAIR_RATE: expected={expected}, got={hp_after}"
     );
 }


### PR DESCRIPTION
## Summary

Fixes #169. Two Mason decision paths that iterated all buildings (`iter_instances + query.get`) are replaced with `for_each_nearby` spatial queries:

- **FINDING-3** (repair-at-site, 40px radius): `decision/mod.rs:2231`
- **FINDING-4** (idle work-target search, 6400px radius): `decision/mod.rs:2865`

Both sites now use O(buildings_in_radius) instead of O(all_buildings).

## Benchmark

A new `mason_decision_building_scale` benchmark is added to `system_bench.rs` to measure the spatial query at 1K / 10K / 50K building counts.

The benchmark spawns a single Mason at the world center of a 32768px map with buildings spread uniformly. Only ~12% of buildings fall within the 6400px search radius (`MASON_SEARCH_RADIUS`), so the spatial query visits ~6K cells at 50K buildings instead of all 50K.

**Before/after numbers require local hardware** -- k3s pods have no GPU/display and cannot run Criterion benchmarks. Flagging as **needs local bench** for human verification.

Expected scaling:
| Building count | Spatial cells visited | Old iter_instances |
|---|---|---|
| 1K | ~120 | 1K |
| 10K | ~1,200 | 10K |
| 50K | ~6,000 | 50K |

The spatial scan cost is ~8x lower at 50K buildings because the for_each_nearby path only visits cells overlapping the search radius bbox.

## Tests

- `mason_selects_nearest_damaged_building` -- mason picks nearest damaged building
- `mason_idles_when_no_buildings_damaged` -- mason stays idle at full HP
- `mason_repair_increments_health_caps_at_max` -- repair math correct
- `mason_repairs_nearby_damaged_building_in_active_state` -- regression test: HP increases by MASON_REPAIR_RATE each tick

## Compliance

- **k8s.md**: building_def() called per-instance (not cached); no Def fields stored on instances
- **authority.md**: Health stays CPU-authoritative; no GPU readback used for repair gating
- **performance.md**: Hot Path Rule #6 eliminated in both FINDING-3 and FINDING-4 sites