### PR TITLE
fix: remove iter_npcs+query.get debug sampling from damage_system (#170)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-03-19
+
+- **damage_system iter_npcs+get removed** -- removed `iter_npcs() + query.get()` debug sampling from `damage_system` FixedUpdate hot path (issue #170). `health_samples` field was write-only dead code (never read outside the system); removed field from `HealthDebug` entirely along with the 6-line sampling block. Regression test added to health/tests.rs verifying the system processes damage correctly without the antipattern.
+
 ## 2026-03-14
 
 - **Input hit-test perf fix** -- `click_to_select_system` no longer scans the full GPU readback bucket for NPC picking. Left-click selection and DirectControl right-click enemy targeting now iterate live NPCs from `EntityMap`, still read GPU positions by slot, and skip dead/hidden/out-of-bounds entries. Added regression tests covering sparse live slots plus padded readback buffers. `cargo test --lib` passing (266 tests).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-03-21
+
+- **fix: regression test for issue #170** -- `damage_system_no_iter_npcs_sampling` now checks HP reduction instead of `damage_processed`. FixedUpdate runs 64 sub-ticks per `app.update()` with `ManualDuration(1.0s)`, causing `damage_processed` to be overwritten to 0 by later ticks. HP is set once on the first tick and unchanged thereafter.
+
 ## 2026-03-19
 
 - **damage_system iter_npcs+get removed** -- removed `iter_npcs() + query.get()` debug sampling from `damage_system` FixedUpdate hot path (issue #170). `health_samples` field was write-only dead code (never read outside the system); removed field from `HealthDebug` entirely along with the 6-line sampling block. Regression test added to health/tests.rs verifying the system processes damage correctly without the antipattern.

--- a/rust/src/resources.rs
+++ b/rust/src/resources.rs
@@ -371,7 +371,6 @@ pub struct HealthDebug {
     pub deaths_this_frame: usize,
     pub despawned_this_frame: usize,
     pub bevy_entity_count: usize,
-    pub health_samples: Vec<(usize, f32)>,
     // Healing debug
     pub healing_npcs_checked: usize,
     pub healing_positions_len: usize,

--- a/rust/src/systems/health/mod.rs
+++ b/rust/src/systems/health/mod.rs
@@ -167,13 +167,6 @@ pub fn damage_system(
 
     debug.damage_processed = damage_count;
     debug.bevy_entity_count = entity_map.npc_count();
-    debug.health_samples.clear();
-    if damage_count > 0 {
-        for npc in entity_map.iter_npcs().take(10) {
-            let hp = npc_health_q.get(npc.entity).map(|h| h.0).unwrap_or(0.0);
-            debug.health_samples.push((npc.slot, hp));
-        }
-    }
 }
 
 fn hide_npc(

--- a/rust/src/systems/health/tests.rs
+++ b/rust/src/systems/health/tests.rs
@@ -367,6 +367,39 @@ fn damage_building_reduces_health() {
     );
 }
 
+/// Regression test for issue #170: damage_system must not use iter_npcs+query.get.
+/// The health_samples field was removed from HealthDebug (it was write-only dead code).
+/// This test verifies the system runs correctly with many NPCs and a damage event,
+/// confirming the iter_npcs+get pattern is absent (reverting would require re-adding
+/// health_samples to HealthDebug, making this test fail to compile).
+#[test]
+fn damage_system_no_iter_npcs_sampling() {
+    let mut app = setup_damage_app();
+    // Spawn 15 NPCs (more than the old .take(10) sampling limit)
+    for i in 0..15 {
+        spawn_damageable_npc(&mut app, i, i as u64 + 1, 100.0);
+    }
+    let target_entity = {
+        let em = app.world().resource::<EntityMap>();
+        em.get_npc(0).unwrap().entity
+    };
+    app.world_mut()
+        .resource_mut::<PendingDamage>()
+        .0
+        .push(DamageMsg {
+            target: target_entity,
+            amount: 10.0,
+            attacker: -1,
+            attacker_faction: 0,
+        });
+    app.update();
+    let debug = app.world().resource::<HealthDebug>();
+    assert_eq!(
+        debug.damage_processed, 1,
+        "damage_system should process 1 event without iter_npcs+get sampling"
+    );
+}
+
 // -- update_healing_zone_cache -------------------------------------------
 
 #[derive(Resource, Default)]

--- a/rust/src/systems/health/tests.rs
+++ b/rust/src/systems/health/tests.rs
@@ -369,9 +369,8 @@ fn damage_building_reduces_health() {
 
 /// Regression test for issue #170: damage_system must not use iter_npcs+query.get.
 /// The health_samples field was removed from HealthDebug (it was write-only dead code).
-/// This test verifies the system runs correctly with many NPCs and a damage event,
-/// confirming the iter_npcs+get pattern is absent (reverting would require re-adding
-/// health_samples to HealthDebug, making this test fail to compile).
+/// Spawns 15 NPCs (more than the old .take(10) sampling limit) and verifies damage
+/// is applied correctly, proving the system works with many NPCs after the fix.
 #[test]
 fn damage_system_no_iter_npcs_sampling() {
     let mut app = setup_damage_app();
@@ -393,10 +392,12 @@ fn damage_system_no_iter_npcs_sampling() {
             attacker_faction: 0,
         });
     app.update();
-    let debug = app.world().resource::<HealthDebug>();
-    assert_eq!(
-        debug.damage_processed, 1,
-        "damage_system should process 1 event without iter_npcs+get sampling"
+    // Check HP: damage_processed is overwritten to 0 by later FixedUpdate sub-ticks
+    // within the same app.update(), so HP is the correct signal.
+    let hp = app.world().get::<Health>(target_entity).unwrap().0;
+    assert!(
+        (hp - 90.0).abs() < 0.01,
+        "damage should reduce HP from 100 to 90 with 15 NPCs in world: {hp}"
     );
 }
 


### PR DESCRIPTION
Fixes #170.

## Changes

- `rust/src/systems/health/mod.rs`: removed `iter_npcs() + query.get()` sampling block. Removed `debug.health_samples.clear()` call.
- `rust/src/resources.rs`: removed `health_samples: Vec<(usize, f32)>` field from `HealthDebug`. Field was write-only dead code.
- `rust/src/systems/health/tests.rs`: `damage_system_no_iter_npcs_sampling` regression test fixed. Now asserts HP reduction (90.0 after 10 damage) instead of `debug.damage_processed`. Root cause of previous failure: `FixedUpdate` runs 64 sub-ticks per `app.update()` with `ManualDuration(1.0s)`, so later ticks overwrite `damage_processed` back to 0. HP is set once on tick 1 and unchanged.

## Compliance

- **k8s.md**: no Def/Instance/Controller changes -- compliant
- **authority.md**: health is CPU-authoritative, no GPU readback data touched -- compliant
- **performance.md**: Hot Path Rule #6 violation removed. No new hot-path patterns introduced.

## Acceptance: 4/4 criteria verified

| Criterion | Status |
|-----------|--------|
| `iter_npcs() + query.get()` removed from damage_system FixedUpdate path | PASS |
| Debug sampling removed (field was write-only dead code) | PASS |
| Query-first approach: N/A (sampling removed entirely) | PASS |
| Compliance verified against all 3 docs | PASS |

`cargo clippy --release -- -D warnings` clean. Test linking requires ALSA (unavailable in k3s) -- needs local run.