### PR TITLE
docs: audit and update docs for recent perf/feature changes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -154,7 +154,11 @@ rust/
     systemparams.rs       # TownAccess and other shared SystemParam bundles
     save.rs               # Save/load (quicksave, autosave, named saves, version migration) -> [save-load.md]
     settings.rs           # UserSettings persistence (serde JSON, version migration, key bindings)
-    world.rs              # WorldGrid, procedural gen, place/destroy_building, auto-tile, BuildingKind
+    world/                # WorldGrid, procedural gen, place/destroy_building, auto-tile, BuildingKind
+      mod.rs              # WorldGrid, core types, place/destroy_building, BuildingKind
+      worldgen.rs         # Procedural world generation
+      buildings.rs        # Building placement helpers, resolve_spawner_npc
+      autotile.rs         # Wall auto-tile logic
     ui/
       mod.rs              # UI registration, startup/cleanup, pause menu, settings panel, game over -> [ui.md]
       main_menu.rs        # World/difficulty config, AI lobby, play/load/settings/exit
@@ -170,24 +174,24 @@ rust/
       tutorial.rs         # 24-step guided tutorial with condition-driven advance
     systems/
       spawn.rs            # materialize_npc() single spawn path → [spawn.md]
-      stats.rs            # UpgradeRegistry, resolve_combat_stats, auto-upgrade/equip systems
+      stats/              # UpgradeRegistry, resolve_combat_stats, auto-upgrade/equip systems
       drain.rs            # Queue drain (CombatLogMsg → CombatLog)
       movement.rs         # GPU position readback, HPA* path routing, MovementIntent resolution
+      pathfinding.rs      # HPA* cache build, chunk rebuild, A* pathfinder
       combat.rs           # Attack cooldown, GPU targeting, projectile fire, tower system → [combat.md]
-      health.rs           # Damage, death (XP/loot/cleanup), healing, HP regen → [combat.md]
+      health/             # Damage, death (XP/loot/cleanup), healing, HP regen → [combat.md]
       behavior.rs         # SystemParam bundles, arrival_system coordinator → [behavior.md]
       decision/
         mod.rs            # decision_system, utility AI, flee/leash, transition helpers → [behavior.md]
-        tests.rs          # 36 decision system tests (lifecycle, squad, phase validation)
+        tests.rs          # decision system tests (lifecycle, squad, phase, mason validation)
       patrol.rs           # on_duty_tick_system, rebuild_patrol_routes_system → [behavior.md]
       work_targeting.rs   # Centralized worksite claim/release/retarget resolver
       economy/            # Farm/mine growth, construction, spawner respawn, migration → [economy.md]
-      ai_player.rs        # AI personalities, building scoring, squad commander → [ai-player.md]
+      ai_player/          # AI personalities, building scoring, squad commander → [ai-player.md]
       audio.rs            # Music jukebox (22 tracks) + spatial SFX -> [audio.md]
       remote.rs           # Custom BRP endpoints (summary, build, upgrade, etc.) → [brp.md]
       llm_player.rs       # Built-in claude --print LLM player → [llm-player.md]
       energy.rs           # Energy drain/recovery
-      sync.rs             # GPU state sync
     tests/
       mod.rs              # Test framework (TestState, menu, HUD, CLI runner)
       (25 test files)     # See test table above for full list

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -16,9 +16,9 @@ Current implementation only: the target-state redesign spec lives in [npc-activi
 **Unified Decision System**: All NPC decisions are handled by `decision_system` using a priority cascade. NPC state is modeled by two orthogonal components (concurrent state machines pattern):
 
 - `Activity` struct: what the NPC is *doing*. Contains `kind: ActivityKind` + `phase: ActivityPhase` + `target: ActivityTarget` + `ticks_waiting: u32` + `recover_until: f32` (Heal HP threshold). All 10 activities use explicit phase/target. No `target_pos` -- destination identity lives in `ActivityTarget` variants or `NpcWorkState.worksite`.
-- `ActivityKind` enum (10 fieldless variants): `Idle, Work, Patrol, SquadAttack, Rest, Heal, Wander, Raid, ReturnLoot, Mine`. Derives `Copy + Eq + Hash`. Registry key — metadata lives in `ACTIVITY_REGISTRY` (constants.rs).
+- `ActivityKind` enum (11 fieldless variants): `Idle, Work, Patrol, SquadAttack, Rest, Heal, Wander, Raid, ReturnLoot, Mine, Repair`. Derives `Copy + Eq + Hash`. Registry key — metadata lives in `ACTIVITY_REGISTRY` (constants.rs).
 - `ActivityDef` struct (constants.rs): per-kind metadata — `label`, `distraction`, `sleep_visual`, `is_restful`, `is_working`. Accessed via `kind.def()` or `activity_def(kind)`.
-- `Distraction` enum: per-activity combat policy — `None` (Rest/Heal/ReturnLoot: never fight), `ByDamage` (Work/Mine: fight back only when hit), `ByEnemy` (Patrol/SquadAttack/Idle/Wander/Raid: engage nearby enemies). Queried via `activity.kind.distraction()` (delegates to registry).
+- `Distraction` enum: per-activity combat policy — `None` (Rest/Heal/ReturnLoot: never fight), `ByDamage` (Work/Mine/Repair: fight back only when hit), `ByEnemy` (Patrol/SquadAttack/Idle/Wander/Raid: engage nearby enemies). Queried via `activity.kind.distraction()` (delegates to registry).
 - `CombatState` enum: whether the NPC is *fighting* (None, Fighting, Fleeing)
 - `NpcFlags::at_destination`: replaces the old transit/at-dest split — a single boolean distinguishes "walking to work" from "working at worksite"
 
@@ -47,7 +47,7 @@ Priority order (first match wins), with two-cadence top-of-loop bucket gating (s
 **Priority 4-7 — idle/work decisions** (every bucket tick):
 4a. Heal+Active + HP >= threshold → Wake to `Idle+Ready`; Heal+Transit → skip (waiting for arrival)
 4b. Rest+Active + energy >= 90% → Wake to `Idle+Ready`; Rest+Transit → skip (waiting for arrival)
-5. Work/Mine + tired? → Stop work
+5. Work/Mine/Repair + tired? → Stop work
 6. Patrol + time_to_advance? → next waypoint
 7. Idle → Score Eat/Rest/Work/Wander (wounded → fountain, tired → home)
 
@@ -153,7 +153,7 @@ Two concurrent state machines: `Activity.kind` (what NPC is doing) and `CombatSt
     Distraction (per-ActivityKind combat policy):
     ┌─────────────┬──────────────────────────────────┐
     │ None        │ Rest, Heal, ReturnLoot            │
-    │ ByDamage    │ Work, Mine                        │
+    │ ByDamage    │ Work, Mine, Repair                │
     │ ByEnemy     │ Patrol, SquadAttack, Idle,        │
     │             │ Wander, Raid                       │
     └─────────────┴──────────────────────────────────┘
@@ -186,8 +186,9 @@ Two concurrent state machines: `Activity.kind` (what NPC is doing) and `CombatSt
 - `Raid` — **phase-aware**: `Transit+RaidPoint(Vec2)` = walking to enemy farm. Legacy activity (new games use SquadAttack for raiders).
 - `ReturnLoot` — **phase-aware**: `Transit+Dropoff` = carrying loot home. Delivery handled by `arrival_system`.
 - `Mine` — **phase-aware**: `Transit+Worksite` = walking to mine, `Holding+Worksite` = tending/queued. Mine identity from `NpcWorkState.worksite`.
+- `Repair` — **phase-aware**: `Transit+Worksite` = walking to damaged building, `Active+Worksite` = repairing. Mason NPC only. Uses `for_each_nearby` spatial search to find and repair the nearest damaged same-faction building within a 40px radius.
 
-**Distraction enum** (per-activity combat policy): `None` (Rest/Heal/ReturnLoot), `ByDamage` (Work/Mine), `ByEnemy` (all others). Queried via `activity.kind.distraction()`. Used by `attack_system` to skip non-combatants.
+**Distraction enum** (per-activity combat policy): `None` (Rest/Heal/ReturnLoot), `ByDamage` (Work/Mine/Repair), `ByEnemy` (all others). Queried via `activity.kind.distraction()`. Used by `attack_system` to skip non-combatants.
 
 **Activity methods**: `Activity::new(kind)` constructor, `visual_key()` for GPU sprite selection (sleep icon when `phase == Active` + `sleep_visual`), `name()` for display label.
 
@@ -202,6 +203,8 @@ Two concurrent state machines: `Activity.kind` (what NPC is doing) and `CombatSt
 `Heal` — HP recovery at fountain. `recover_until` threshold stored in Activity payload. Phase-aware: `Transit+Fountain` = walking to fountain, `Active+Fountain` = healing. Early arrival: NPCs within 100px of town center transition directly to `Active` even if `at_destination` not yet set.
 
 `Mine` — mine position stored in `target_pos` payload. `at_destination` = actively extracting gold (claims occupancy, progress-based 4-hour work cycle with gold progress bar overhead). Pending Slice 3 phase migration.
+
+`Repair` — Mason activity. `Transit+Worksite` = walking to damaged building, `Active+Worksite` = repairing. On arrival: uses `entity_map.for_each_nearby(pos, 40px)` to find the nearest same-faction damaged building, restores it to full HP, logs repair. When no damaged buildings found nearby, transitions to `Idle`. `Distraction::ByDamage` — mason fights back only when hit.
 
 ### NPC ECS Components
 

--- a/docs/combat.md
+++ b/docs/combat.md
@@ -228,9 +228,9 @@ Slots are raw `usize` indices without generational counters. This is safe becaus
 - sample_target_idx, sample_dist, sample_timer
 - in_range_count, timer_ready_count
 
-`HealthDebug` (Bevy Resource) updated by damage/death/healing systems:
+`HealthDebug` (Bevy Resource) updated by damage/death/healing systems (`systems/health/mod.rs`):
 - damage_processed, deaths_this_frame, despawned_this_frame, bevy_entity_count
-- healing_npcs_checked, healing_in_zone_count, healing_healed_count
+- healing_npcs_checked, healing_positions_len, healing_towns_count, healing_in_zone_count, healing_healed_count, healing_active_count, healing_enter_checks, healing_exits
 
 ## Known Issues / Limitations
 

--- a/docs/economy.md
+++ b/docs/economy.md
@@ -21,7 +21,7 @@ game_time_system (every frame)
     │   └─ Each raider town gains RAIDER_FORAGE_RATE food
     │
     ├─ spawner_respawn_system (hourly)
-    │   └─ Detects dead NPCs linked to FarmerHome/ArcherHome/FighterHome/Tent/MinerHome, counts down 12h timer, spawns replacement
+    │   └─ Detects dead NPCs linked to FarmerHome/ArcherHome/FighterHome/Tent/MinerHome/MasonHome, counts down 12h timer, spawns replacement
     │
     ├─ starvation_system (hourly)
     │   └─ NPCs with zero energy → Starving marker
@@ -89,7 +89,7 @@ game_time_system (every frame)
 - Timer decrements 1.0 per game hour; on expiry: allocates slot via `SlotAllocator`, emits `SpawnNpcMsg`, logs to `CombatLog`
 - All spawner buildings (world gen and player-built) start with `SpawnerState { npc_slot: None, respawn_timer: 0.0 }` — the system spawns the first NPC on the next hourly tick. No separate initial spawn function.
 - Tombstoned entries (position.x < -9000) are skipped (building was destroyed)
-- Spawn mapping resolved by `world::resolve_spawner_npc()` (single source of truth, takes `&BuildingInstance`): FarmerHome → Farmer (nearest farm via `find_nearest_free` with kind-filtered spatial search as hint, no claim at spawn — farmer self-claims via behavior system), ArcherHome → Archer (nearest waypoint via `find_location_within_radius`), FighterHome → Fighter (nearest waypoint via `find_location_within_radius`), Tent → Raider (home = tent position), MinerHome → Miner (assigned mine from `MinerHomeConfig.assigned_mine` if set, otherwise nearest gold mine via `find_nearest_free`). All types look up faction from `world_data.towns[town_idx].faction`. Note: spawner_respawn_system does **not** pre-claim work slots — farmers self-claim via `find_farmer_farm_target()` in decision_system.
+- Spawn mapping resolved by `world::resolve_spawner_npc()` (single source of truth, takes `&BuildingInstance`): FarmerHome → Farmer (nearest farm via `find_nearest_free` with kind-filtered spatial search as hint, no claim at spawn — farmer self-claims via behavior system), ArcherHome → Archer (nearest waypoint via `find_location_within_radius`), FighterHome → Fighter (nearest waypoint via `find_location_within_radius`), Tent → Raider (home = tent position), MinerHome → Miner (assigned mine from `MinerHomeConfig.assigned_mine` if set, otherwise nearest gold mine via `find_nearest_free`), MasonHome → Mason (home = mason home position, no initial worksite — mason self-selects damaged buildings via decision_system). All types look up faction from `world_data.towns[town_idx].faction`. Note: spawner_respawn_system does **not** pre-claim work slots — farmers self-claim via `find_farmer_farm_target()` in decision_system.
 
 ### starvation_system
 - Query-first: `(&GpuSlot, &Energy, &CachedStats, &mut NpcFlags, &mut Health)` with `Without<Building>, Without<Dead>` — no `EntityMap` dependency

--- a/docs/frame-loop.md
+++ b/docs/frame-loop.md
@@ -2,9 +2,13 @@
 
 ## Overview
 
-Pure Bevy application with a **Factorio-style fixed 60 UPS game loop**. All game logic runs on Bevy's `FixedUpdate` schedule at exactly 60 ticks/second (16.67ms/tick). `Time.delta_secs()` in FixedUpdate always returns `1/60`. Rendering and UI run on `Update` (per render frame). The main and render worlds synchronize once per frame at the extract barrier.
+Pure Bevy application with a **Factorio-style fixed game loop**. All game logic runs on Bevy's `FixedUpdate` schedule. Rendering and UI run on `Update` (per render frame). The main and render worlds synchronize once per frame at the extract barrier.
 
-`GameTime::delta()` multiplies the fixed dt by `time_scale` — the simulation is deterministic regardless of frame rate. `UpsCounter` resource tracks actual ticks/second for the HUD (incremented in FixedUpdate, sampled per frame in the top bar).
+**At 1x speed**: Fixed runs at 60 Hz (16.67ms/tick). `Time.delta_secs()` returns `1/60`.
+
+**At speeds > 1x**: `sync_fixed_hz` (Update schedule) scales the Fixed period to `sqrt(time_scale)/60`. At 4x: 30 Hz, at 8x: ~21 Hz, at 16x: 15 Hz. This prevents cascade (too many ticks per frame) while keeping UPS in a playable range. `Time.delta_secs()` returns the current Fixed timestep (`sqrt(time_scale)/60`). See [performance.md](performance.md#time-scale-scheduling-sync_fixed_hz) for the full table and rationale.
+
+`GameTime::delta()` multiplies the fixed dt by `time_scale` — game-time proportionality is preserved at all speeds. `UpsCounter` resource tracks actual ticks/second for the HUD (incremented in FixedUpdate, sampled per frame in the top bar).
 
 ## Execution Order
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -203,7 +203,7 @@ All volatile numeric constants in one place. Policy sections above describe *why
 | Threat readback throttle | 30 frames | `gpu.rs` |
 | Farm visual cadence | event-driven (FarmReadyMsg/FarmHarvestedMsg) | `economy/mod.rs` |
 | ProfilerCache refresh | 15 frames, top 10 | `ui/game_hud.rs` |
-| Healing enter-check cadence | 1/4 NPCs per frame | `health.rs` |
+| Healing enter-check cadence | 1/4 NPCs per frame | `systems/health/mod.rs` |
 | Gap coalescing waste budget | ~24KB total across all buffers | `gpu.rs` |
 | Visual upload fallback | 40% window → bulk offset write | `gpu.rs` |
 | `max_pathfinds_per_frame` | 50 | `resources.rs` (PathfindConfig) |

--- a/docs/rendering.md
+++ b/docs/rendering.md
@@ -5,7 +5,7 @@
 **Terrain** uses Bevy's built-in `TilemapChunk` (single layer, `AlphaMode2d::Opaque`, z=-1). **Everything else** — buildings, NPCs, equipment, farms, building HP bars, projectiles — uses a custom GPU pipeline via Bevy's RenderCommand pattern in the Transparent2d phase. Explicit sort keys guarantee deterministic layer ordering (`CompareFunction::Always`, no depth testing between passes). Two render paths share one pipeline with a `StorageDrawMode` specialization key:
 
 - **Storage buffer path** (NPCs + selection brackets): `vertex_npc` shader entry point reads positions/health directly from compute shader's `NpcGpuBuffers` storage buffers (bind group 2). Visual/equipment data uploaded from CPU as flat storage buffers (`NpcVisualBuffers`). Three specialized variants via `#ifdef` shader defs: `MODE_NPC_BODY` (layer 0, non-building only), `MODE_NPC_OVERLAY` (layers 1-7, non-building only), `MODE_SELECTION_BRACKET` (procedural corner brackets from per-instance style data).
-- **Instance buffer path** (buildings, building overlays, projectiles): `vertex` shader entry point reads from classic per-instance `InstanceData` vertex attributes (slot 1). Building bodies use `BuildingBodyInstances` built each frame from `EntityGpuState` via `EntityMap.iter_instances()`.
+- **Instance buffer path** (buildings, building overlays, projectiles): `vertex` shader entry point reads from classic per-instance `InstanceData` vertex attributes (slot 1). Building bodies use `BuildingBodyInstances` built by `build_building_body_instances` (PostUpdate) only when `BuildingBodyDirty` is set — skips the O(68K) rebuild when nothing has changed (placement, removal, HP change, or damage flash).
 
 Four textures bound simultaneously (group 0, bindings 0-7) — `atlas_id` selects which to sample (0=character, 1=world, 2=heal/3=sleep/4=arrow/8=boat via extras atlas, 7=building). Bar-only modes: 5=building HP bar (green/yellow/red), 6=mining progress bar (gold). Procedural mode: 9=selection brackets (no texture sampling, corner brackets from quad_uv). Atlas ID constants defined in `constants.rs` (`ATLAS_CHAR` through `ATLAS_BOAT`).
 
@@ -380,7 +380,7 @@ type DrawNpcOverlayCommands = (..., DrawStoragePass<false>);   // + MODE_NPC_OVE
 ```rust
 type DrawBuildingBodyCommands = (..., DrawBuildingBody);
 ```
-`DrawBuildingBody::render()` reads `BuildingBodyRenderBuffers` — a `RawBufferVec<InstanceData>` built each frame from `EntityGpuState` (positions, factions, health, sprite indices, flash) by `build_building_body_instances` (PostUpdate). Building slots are obtained by iterating `EntityMap.iter_instances()` and indexing into the unified `EntityGpuState` arrays.
+`DrawBuildingBody::render()` reads `BuildingBodyRenderBuffers` — a `RawBufferVec<InstanceData>` built by `build_building_body_instances` (PostUpdate) only when `BuildingBodyDirty` is set (skips O(68K) rebuild when nothing changed). Reads position and faction from `BuildingInstance` (compact `DenseSlotMap`, cache-friendly) rather than the scattered 200K-element `EntityGpuState` arrays. Only sprite indices and flash values are read from `EntityGpuState`. Pre-builds `under_construction_by_slot` via `Query<(&GpuSlot, &ConstructionProgress)>` (O(under_construction), not O(all_buildings)).
 
 The shader derives `slot` and `layer` from `instance_index`. Compile-time `#ifdef` gating discards unwanted slots per pass (buildings vs non-buildings). Hidden NPCs (`pos.x < -9000`) and empty equipment slots (`col < 0`) are culled by moving clip_position off-screen.
 

--- a/docs/spawn.md
+++ b/docs/spawn.md
@@ -65,7 +65,7 @@ GPU dispatch count comes from `GpuSlotPool.count()` (the high-water mark `next`)
 |-------|------|-------|
 | slot_idx | usize | Pre-allocated via GpuSlotPool |
 | x, y | f32 | Spawn position |
-| job | i32 | 0=Farmer, 1=Archer, 2=Raider, 3=Fighter, 4=Miner, 5=Crossbow |
+| job | i32 | 0=Farmer, 1=Archer, 2=Raider, 3=Fighter, 4=Miner, 5=Crossbow, 6=Boat, 7=Woodcutter, 8=Quarrier, 9=Mason |
 | faction | i32 | 0=Player, 1+=AI settlements |
 | town_idx | i32 | Town association (-1 = none) |
 | home_x, home_y | f32 | Home position |
@@ -94,6 +94,10 @@ Job-specific optional components:
 | Miner | HasEnergy |
 | Raider | HasEnergy, Stealer, LeashRange(400), EquippedWeapon |
 | Fighter | HasEnergy, PatrolRoute, `Activity::new(ActivityKind::Patrol)` |
+| Woodcutter | HasEnergy |
+| Quarrier | HasEnergy |
+| Mason | HasEnergy |
+| Boat | (none — temporary migration unit, despawned on arrival) |
 
 GPU writes (all jobs): `SetPosition`, `SetTarget` (spawn position; save-restore path may set work position for farmers), `SetSpeed(100)`, `SetFaction`, `SetHealth(100)`, `SetSpriteFrame` (job-based sprite from constants.rs), `SetFlags` (bit 0 = 1 for military jobs via `job.is_military()`, 0 for farmers/miners — controls GPU combat scan tier). Fresh spawns start with `NpcWorkState { worksite: None }` — behavior system assigns work via `WorkIntentMsg` later. Save/restore path may restore explicit `worksite` (converted from slot to Entity via `entities.get(&slot)`). Colors and equipment sprites are derived from ECS component data by `build_visual_upload` (queries `EquippedWeapon/Helmet/Armor` components).
 
@@ -113,7 +117,7 @@ Deterministic: adjective + job noun. Adjective cycles through a 10-word list, no
 
 ## Building Spawners
 
-All NPC population is building-driven: each **FarmerHome** supports 1 farmer, each **ArcherHome** supports 1 archer, each **CrossbowHome** supports 1 crossbowman, each **FighterHome** supports 1 fighter, each **MinerHome** supports 1 miner, and each **Tent** supports 1 raider. No NPCs are spawned directly at world gen — homes are placed with `respawn_timer: 0.0` and `spawner_respawn_system` spawns their NPCs on the first hour tick. Menu sliders control how many FarmerHomes/ArcherHomes/MinerHomes/Tents world gen places.
+All NPC population is building-driven: each **FarmerHome** supports 1 farmer, each **ArcherHome** supports 1 archer, each **CrossbowHome** supports 1 crossbowman, each **FighterHome** supports 1 fighter, each **MinerHome** supports 1 miner, each **MasonHome** supports 1 mason, and each **Tent** supports 1 raider. No NPCs are spawned directly at world gen — homes are placed with `respawn_timer: 0.0` and `spawner_respawn_system` spawns their NPCs on the first hour tick. Menu sliders control how many FarmerHomes/ArcherHomes/MinerHomes/Tents world gen places.
 
 When an NPC dies, `spawner_respawn_system` (hourly, Step::Behavior) detects the death via `EntityMap` lookup, starts a 12-hour respawn timer, and spawns a replacement when it expires. New spawner buildings placed at runtime start with `respawn_timer: 0.0` — the system spawns the NPC on the next hourly tick. Raider grids only allow Tent placement; villager grids allow Farm/Waypoint/FarmerHome/ArcherHome/CrossbowHome/FighterHome/MinerHome.
 


### PR DESCRIPTION
## Summary

- `README.md`: file map updated — `world/`, `health/`, `stats/`, `ai_player/` are now directories; added `pathfinding.rs`; removed defunct `sync.rs`
- `frame-loop.md`: document sqrt-scaled Fixed Hz at speeds > 1x via `sync_fixed_hz` (was missing entirely)
- `rendering.md`: `BuildingBodyInstances` is now dirty-tracked (`BuildingBodyDirty`), not rebuilt every frame; `build_building_body_instances` reads from compact `BuildingInstance` not scattered 200K arrays
- `combat.md`: add missing `HealthDebug` fields (`healing_positions_len`, `healing_towns_count`, `healing_active_count`, `healing_enter_checks`, `healing_exits`); correct path to `systems/health/mod.rs`
- `behavior.md`: `ActivityKind` updated from 10 to 11 variants (add `Repair`); `Distraction::ByDamage` now lists `Repair`; document mason/Repair behavior and spatial-search pattern
- `spawn.md`: job list and optional-components table extended with Boat(6), Woodcutter(7), Quarrier(8), Mason(9); `MasonHome` added to Building Spawners section
- `economy.md`: `MasonHome` added to `spawner_respawn_system` data flow and spawn mapping
- `performance.md`: `health.rs` tuning reference corrected to `systems/health/mod.rs`

## Test plan

- [ ] Docs-only PR: no code changes, no test execution required
- [ ] Verified each change against current source files in `rust/src/`
- [ ] No acceptance criteria checkboxes in issue body beyond the doc audit list

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)