### PR TITLE
feat: continental world gen -- 3-10 continents, 6+ biomes, rivers, volcanoes

### DIFF
--- a/rust/src/gpu.rs
+++ b/rust/src/gpu.rs
@@ -1396,9 +1396,12 @@ fn populate_tile_flags(
                 flags[idx] = match cell.terrain {
                     crate::world::Biome::Grass => crate::constants::TILE_GRASS,
                     crate::world::Biome::Forest => crate::constants::TILE_FOREST,
+                    crate::world::Biome::Jungle => crate::constants::TILE_FOREST,
                     crate::world::Biome::Water => crate::constants::TILE_WATER,
                     crate::world::Biome::Rock => crate::constants::TILE_ROCK,
                     crate::world::Biome::Dirt => crate::constants::TILE_DIRT,
+                    crate::world::Biome::Desert => crate::constants::TILE_GRASS,
+                    crate::world::Biome::Tundra => crate::constants::TILE_GRASS,
                 };
             }
         }

--- a/rust/src/save.rs
+++ b/rust/src/save.rs
@@ -773,6 +773,9 @@ fn biome_to_u8(b: world::Biome) -> u8 {
         world::Biome::Water => 2,
         world::Biome::Rock => 3,
         world::Biome::Dirt => 4,
+        world::Biome::Desert => 5,
+        world::Biome::Tundra => 6,
+        world::Biome::Jungle => 7,
     }
 }
 
@@ -782,6 +785,9 @@ fn u8_to_biome(v: u8) -> world::Biome {
         2 => world::Biome::Water,
         3 => world::Biome::Rock,
         4 => world::Biome::Dirt,
+        5 => world::Biome::Desert,
+        6 => world::Biome::Tundra,
+        7 => world::Biome::Jungle,
         _ => world::Biome::Grass,
     }
 }

--- a/rust/src/systems/combat.rs
+++ b/rust/src/systems/combat.rs
@@ -682,10 +682,10 @@ pub fn process_proj_hits(
                     let (gc, gr) = grid.world_to_grid(Vec2::new(tx, ty));
                     if grid
                         .cell(gc, gr)
-                        .is_some_and(|c| c.terrain == Biome::Forest)
+                        .is_some_and(|c| matches!(c.terrain, Biome::Forest | Biome::Jungle))
                         && rng.random_range(0.0..1.0_f32) < 0.25
                     {
-                        // Miss -- projectile absorbed by forest cover
+                        // Miss -- projectile absorbed by forest/jungle cover
                         proj_alloc.free(slot);
                         proj_updates
                             .write(ProjGpuUpdateMsg(ProjGpuUpdate::Deactivate { idx: slot }));

--- a/rust/src/ui/mod.rs
+++ b/rust/src/ui/mod.rs
@@ -2248,9 +2248,7 @@ fn build_ghost_system(
         build_ctx.hover_world_pos = snapped;
         let cell = grid.cell(gc, gr);
         let empty = !entity_map.has_building_at(gc as i32, gr as i32);
-        let buildable_terrain = cell
-            .map(|c| !matches!(c.terrain, world::Biome::Water | world::Biome::Rock))
-            .unwrap_or(false);
+        let buildable_terrain = cell.map(|c| !c.terrain.is_impassable()).unwrap_or(false);
         let valid = empty && buildable_terrain;
         build_ctx.show_cursor_hint = !valid;
 

--- a/rust/src/world/buildings.rs
+++ b/rust/src/world/buildings.rs
@@ -288,7 +288,7 @@ pub fn place_building(
         if entity_map.has_building_at(gc as i32, gr as i32) {
             return Err("cell already has a building");
         }
-        if matches!(cell.terrain, Biome::Water | Biome::Rock) {
+        if cell.terrain.is_impassable() {
             return Err("cannot build on water or rock");
         }
         if kind.is_road() && cell.terrain == Biome::Forest {

--- a/rust/src/world/mod.rs
+++ b/rust/src/world/mod.rs
@@ -589,20 +589,34 @@ pub enum Biome {
     Water,
     Rock,
     Dirt,
+    /// Hot, arid terrain -- low moisture, mid-to-high temperature.
+    Desert,
+    /// Cold, barren terrain -- near-polar zones.
+    Tundra,
+    /// Dense tropical forest -- high moisture, high temperature.
+    Jungle,
 }
 
 impl Biome {
     /// Map biome + cell index to tileset array index for TilemapChunk.
     /// Trees and rocks are full entities now -- Forest/Rock biomes render as ground only.
-    /// Grass=0, Forest=1 (dark grass), Water=8, Rock=10 (dirt), Dirt=10.
+    /// Grass=0, Forest/Jungle=1 (dark grass), Water=8, Rock/Tundra=9, Dirt/Desert=10.
     pub fn tileset_index(self, _cell_index: usize) -> u16 {
         match self {
             Biome::Grass => 0,
             Biome::Forest => 1,
+            Biome::Jungle => 1,
             Biome::Water => 8,
-            Biome::Rock => 10,
+            Biome::Rock => 9,
+            Biome::Tundra => 9,
             Biome::Dirt => 10,
+            Biome::Desert => 10,
         }
+    }
+
+    /// True if this biome blocks NPC movement (impassable).
+    pub fn is_impassable(self) -> bool {
+        matches!(self, Biome::Water | Biome::Rock)
     }
 }
 
@@ -982,10 +996,7 @@ impl WorldGrid {
             return;
         }
         // Skip impassable cells (water, rock)
-        if matches!(
-            self.cells[row * self.width + col].terrain,
-            Biome::Water | Biome::Rock
-        ) {
+        if self.cells[row * self.width + col].terrain.is_impassable() {
             return;
         }
         let idx = row * self.width + col;
@@ -1120,8 +1131,8 @@ impl WorldGrid {
 /// strongly avoids them.
 pub(crate) fn terrain_base_cost(biome: Biome) -> u16 {
     match biome {
-        Biome::Grass | Biome::Dirt => 100,
-        Biome::Forest => 143,
+        Biome::Grass | Biome::Dirt | Biome::Desert => 100,
+        Biome::Forest | Biome::Jungle | Biome::Tundra => 143,
         Biome::Rock => 2500,
         Biome::Water => 5000,
     }

--- a/rust/src/world/tests.rs
+++ b/rust/src/world/tests.rs
@@ -540,8 +540,9 @@ fn worldmap_biomes_follow_latitude() {
     // Fixed seed for determinism.
     generate_terrain_worldmap(&mut grid, 0x1234_5678_9abc_def0);
 
-    // Sample equatorial band (rows 90-110) and near-polar band (rows 25-35)
-    let mut equatorial_grass = 0usize;
+    // Sample equatorial band (rows 90-110) -- should have warm biomes only
+    let mut equatorial_warm = 0usize;
+    let mut equatorial_tundra = 0usize;
     let mut equatorial_total = 0usize;
     let mut polar_rock = 0usize;
     let mut polar_total = 0usize;
@@ -551,8 +552,12 @@ fn worldmap_biomes_follow_latitude() {
             let cell = &grid.cells[row * grid.width + col];
             if cell.terrain != Biome::Water {
                 equatorial_total += 1;
-                if cell.terrain == Biome::Grass {
-                    equatorial_grass += 1;
+                match cell.terrain {
+                    Biome::Grass | Biome::Forest | Biome::Jungle | Biome::Desert => {
+                        equatorial_warm += 1;
+                    }
+                    Biome::Tundra => equatorial_tundra += 1,
+                    _ => {}
                 }
             }
         }
@@ -570,11 +575,19 @@ fn worldmap_biomes_follow_latitude() {
         }
     }
 
-    // Equatorial band should have some grass (not all rock/forest)
+    // Equatorial band should have warm biomes (Grass, Forest, Jungle, Desert), not arctic
     if equatorial_total > 0 {
         assert!(
-            equatorial_grass > 0,
-            "equatorial band should have some grass cells"
+            equatorial_warm > 0,
+            "equatorial band should have warm biomes (Grass/Forest/Jungle/Desert), got {}/{} warm, {} tundra",
+            equatorial_warm,
+            equatorial_total,
+            equatorial_tundra,
+        );
+        assert_eq!(
+            equatorial_tundra, 0,
+            "equatorial band should have no tundra cells, got {}",
+            equatorial_tundra,
         );
     }
 
@@ -723,7 +736,161 @@ fn wall_sealing_fountain_is_rejected() {
     );
 }
 
-/// Regression test: placing a wall that leaves a gap is accepted.
+// ============================================================================
+// CONTINENTAL WORLD GEN REGRESSION TESTS (Issue 240)
+// ============================================================================
+
+/// Regression: worldmap with fixed seed produces >= 6 distinct biome types.
+/// This proves the biome table covers the required variety (Grass, Forest, Water, Rock/Tundra, Desert, Jungle).
+#[test]
+fn worldmap_has_six_plus_biome_types() {
+    let mut grid = WorldGrid::default();
+    grid.width = 200;
+    grid.height = 200;
+    grid.cell_size = 64.0;
+    grid.cells = vec![WorldCell::default(); 200 * 200];
+
+    generate_terrain_worldmap(&mut grid, 0xdead_beef_cafe_1234);
+
+    let mut seen = std::collections::HashSet::new();
+    for cell in &grid.cells {
+        seen.insert(std::mem::discriminant(&cell.terrain));
+    }
+    assert!(
+        seen.len() >= 6,
+        "expected >= 6 distinct biome types, got {}",
+        seen.len()
+    );
+}
+
+/// Regression: worldmap uses 3-10 continents from the same seed deterministically.
+/// Two calls with the same seed must produce identical grids (determinism).
+#[test]
+fn worldmap_is_deterministic_for_same_seed() {
+    let make_grid = || {
+        let mut g = WorldGrid::default();
+        g.width = 100;
+        g.height = 100;
+        g.cell_size = 64.0;
+        g.cells = vec![WorldCell::default(); 100 * 100];
+        generate_terrain_worldmap(&mut g, 0x1111_2222_3333_4444);
+        g
+    };
+
+    let g1 = make_grid();
+    let g2 = make_grid();
+
+    let diffs = g1
+        .cells
+        .iter()
+        .zip(g2.cells.iter())
+        .filter(|(a, b)| a.terrain != b.terrain)
+        .count();
+    assert_eq!(
+        diffs, 0,
+        "same seed should produce identical terrain, got {} diffs",
+        diffs
+    );
+}
+
+/// Regression: worldmap rivers -- some cells near continent seeds are Water (rivers carved).
+/// Uses a large grid so rivers have room to form and reach the coast.
+#[test]
+fn worldmap_rivers_carve_water_inland() {
+    let mut grid = WorldGrid::default();
+    grid.width = 200;
+    grid.height = 200;
+    grid.cell_size = 64.0;
+    grid.cells = vec![WorldCell::default(); 200 * 200];
+
+    generate_terrain_worldmap(&mut grid, 0xabcd_ef01_2345_6789);
+
+    // Count water cells excluding ice cap rows
+    let ice_rows = (200.0 * 0.12) as usize;
+    let mid_water = grid
+        .cells
+        .iter()
+        .enumerate()
+        .filter(|(idx, c)| {
+            let row = idx / grid.width;
+            row >= ice_rows && row < grid.height - ice_rows && c.terrain == Biome::Water
+        })
+        .count();
+
+    // With rivers + ocean, mid-grid Water should be > 5% of non-ice cells
+    let mid_cells = (grid.height - 2 * ice_rows) * grid.width;
+    let water_pct = mid_water as f64 / mid_cells as f64;
+    assert!(
+        water_pct > 0.05,
+        "expected > 5% water in mid-grid (rivers + ocean), got {:.1}%",
+        water_pct * 100.0
+    );
+}
+
+/// Regression: worldmap volcanoes -- some Rock clusters exist at non-ice-cap land.
+/// Volcanoes stamp Rock at high-elevation coastal cells. With a large enough grid,
+/// at least some Rock should appear in temperate land zones (not just ice caps).
+#[test]
+fn worldmap_volcanoes_place_rock_in_temperate_zone() {
+    let mut grid = WorldGrid::default();
+    grid.width = 200;
+    grid.height = 200;
+    grid.cell_size = 64.0;
+    grid.cells = vec![WorldCell::default(); 200 * 200];
+
+    generate_terrain_worldmap(&mut grid, 0xfeed_face_dead_beef);
+
+    let ice_rows = (200.0 * 0.12) as usize;
+    // Count Rock cells in temperate mid-zone (rows 30-170)
+    let temperate_rock = grid
+        .cells
+        .iter()
+        .enumerate()
+        .filter(|(idx, c)| {
+            let row = idx / grid.width;
+            row >= ice_rows + 5 && row < grid.height - ice_rows - 5 && c.terrain == Biome::Rock
+        })
+        .count();
+
+    assert!(
+        temperate_rock > 0,
+        "expected some Rock cells in temperate zone (volcanoes), got 0"
+    );
+}
+
+/// Regression: new biome variants (Desert, Tundra, Jungle) have correct passability.
+/// Desert and Jungle are passable; Rock and Water are impassable.
+#[test]
+fn new_biome_passability_contract() {
+    assert!(!Biome::Desert.is_impassable(), "Desert should be passable");
+    assert!(!Biome::Tundra.is_impassable(), "Tundra should be passable");
+    assert!(!Biome::Jungle.is_impassable(), "Jungle should be passable");
+    assert!(Biome::Water.is_impassable(), "Water should be impassable");
+    assert!(Biome::Rock.is_impassable(), "Rock should be impassable");
+}
+
+/// Regression: new biomes have correct pathfinding costs.
+#[test]
+fn new_biome_pathfind_costs() {
+    use crate::world::terrain_base_cost;
+    assert_eq!(
+        terrain_base_cost(Biome::Desert),
+        100,
+        "Desert cost should be 100 (flat)"
+    );
+    assert_eq!(
+        terrain_base_cost(Biome::Tundra),
+        143,
+        "Tundra cost should be 143 (slow)"
+    );
+    assert_eq!(
+        terrain_base_cost(Biome::Jungle),
+        143,
+        "Jungle cost should be 143 (slow)"
+    );
+}
+
+/// Regression: placing a wall that leaves a gap is accepted.
 /// Scenario: 2 walls around fountain, 3rd wall placed -- still has one open neighbor.
 #[test]
 fn wall_leaving_gap_is_accepted() {

--- a/rust/src/world/worldgen.rs
+++ b/rust/src/world/worldgen.rs
@@ -172,7 +172,7 @@ pub(crate) fn spawn_resource_nodes(
         for col in 0..grid.width {
             let idx = row * grid.width + col;
             let kind = match grid.cells[idx].terrain {
-                Biome::Forest => BuildingKind::TreeNode,
+                Biome::Forest | Biome::Jungle => BuildingKind::TreeNode,
                 Biome::Rock => BuildingKind::RockNode,
                 _ => continue,
             };
@@ -286,10 +286,7 @@ pub fn generate_world(
             let pos = Vec2::new(x, y);
             if needs_pre_terrain {
                 let (gc, gr) = grid.world_to_grid(pos);
-                if grid
-                    .cell(gc, gr)
-                    .is_some_and(|c| matches!(c.terrain, Biome::Water | Biome::Rock))
-                {
+                if grid.cell(gc, gr).is_some_and(|c| c.terrain.is_impassable()) {
                     continue;
                 }
             }
@@ -374,10 +371,7 @@ pub fn generate_world(
         // Not on impassable terrain
         if needs_pre_terrain {
             let (gc, gr) = grid.world_to_grid(pos);
-            if grid
-                .cell(gc, gr)
-                .is_some_and(|c| matches!(c.terrain, Biome::Water | Biome::Rock))
-            {
+            if grid.cell(gc, gr).is_some_and(|c| c.terrain.is_impassable()) {
                 continue;
             }
         }
@@ -985,11 +979,12 @@ fn generate_terrain_maze(grid: &mut WorldGrid) {
 }
 
 /// World Map terrain generation: multi-octave noise with continent seeds,
-/// latitude-driven biomes, ice caps, and natural chokepoints.
+/// latitude-driven biomes (6+ types), ice caps, chokepoints, rivers, and volcanoes.
 /// `seed` drives all random choices; pass `rand::random::<u64>()` at runtime,
 /// or a fixed value in tests for determinism.
 pub(crate) fn generate_terrain_worldmap(grid: &mut WorldGrid, seed: u64) {
     use noise::{NoiseFn, Simplex};
+    use rand::Rng;
     use rand::SeedableRng;
 
     let elevation_noise = Simplex::new((seed & 0xffff_ffff) as u32);
@@ -998,40 +993,58 @@ pub(crate) fn generate_terrain_worldmap(grid: &mut WorldGrid, seed: u64) {
 
     let world_w = grid.width as f64 * grid.cell_size as f64;
     let world_h = grid.height as f64 * grid.cell_size as f64;
+    let gw = grid.width;
+    let gh = grid.height;
 
-    // Tunable parameters (fixed defaults for v1)
     let land_pct: f64 = 0.45; // 45% land
     let ice_cap_pct: f64 = 0.12; // 12% of map height at each pole
-    let continent_count: usize = 3;
 
-    // Generate continent seed points for elevation bias
-    let mut continent_seeds: Vec<(f64, f64)> = Vec::with_capacity(continent_count);
+    // Randomize continent count 3-10 from seed
     let mut seed_rng = rand::rngs::SmallRng::seed_from_u64(seed);
-    use rand::Rng;
-    for _ in 0..continent_count {
-        let cx = seed_rng.random_range(0.15..0.85) * world_w;
-        let cy = seed_rng.random_range(0.2..0.8) * world_h;
-        continent_seeds.push((cx, cy));
+    let continent_count: usize = seed_rng.random_range(3..=10);
+
+    // Place continent seed points, keeping them spread apart (>25% world width)
+    let min_sep_sq = (0.25_f64).powi(2); // normalized coords
+    let mut continent_seeds: Vec<(f64, f64)> = Vec::with_capacity(continent_count);
+    let mut attempts = 0usize;
+    while continent_seeds.len() < continent_count && attempts < 2000 {
+        attempts += 1;
+        let cx_n = seed_rng.random_range(0.1..0.9_f64);
+        let cy_n = seed_rng.random_range(0.2..0.8_f64);
+        let ok = continent_seeds.iter().all(|&(ox, oy)| {
+            let dx = cx_n - ox / world_w;
+            let dy = cy_n - oy / world_h;
+            dx * dx + dy * dy >= min_sep_sq
+        });
+        if ok {
+            continent_seeds.push((cx_n * world_w, cy_n * world_h));
+        }
+    }
+    // Fallback: fill remaining slots without separation constraint
+    while continent_seeds.len() < continent_count {
+        let cx_n = seed_rng.random_range(0.1..0.9_f64);
+        let cy_n = seed_rng.random_range(0.2..0.8_f64);
+        continent_seeds.push((cx_n * world_w, cy_n * world_h));
     }
 
-    // Water threshold: lower = more land. Calibrate so ~land_pct of cells are land.
-    // With continent bias, threshold around 0.38-0.42 gives ~45% land.
     let water_threshold: f64 = 0.5 - land_pct * 0.4;
 
-    for row in 0..grid.height {
-        for col in 0..grid.width {
+    // Pass 1: compute elevation map and assign initial biomes
+    let mut elevations = vec![0.0_f64; gw * gh];
+
+    for row in 0..gh {
+        for col in 0..gw {
             let world_pos = grid.grid_to_world(col, row);
             let wx = world_pos.x as f64;
             let wy = world_pos.y as f64;
-
-            // Latitude: 0.0 at top (north pole), 1.0 at bottom (south pole)
             let lat = wy / world_h;
 
-            // Ice caps at poles
+            // Ice caps at poles: impassable
             if lat < ice_cap_pct || lat > (1.0 - ice_cap_pct) {
-                let cell = &mut grid.cells[row * grid.width + col];
-                cell.terrain = Biome::Rock; // impassable ice
+                let cell = &mut grid.cells[row * gw + col];
+                cell.terrain = Biome::Rock;
                 cell.original_terrain = Biome::Rock;
+                elevations[row * gw + col] = 1.0; // treat as high land for river purposes
                 continue;
             }
 
@@ -1042,68 +1055,320 @@ pub(crate) fn generate_terrain_worldmap(grid: &mut WorldGrid, seed: u64) {
                 + 0.125 * elevation_noise.get([wx * 0.002, wy * 0.002]))
                 / 1.875;
 
-            // Continent seed bias: boost elevation near seed points
+            // Continent seed bias: Gaussian boost near seeds
             let mut continent_boost: f64 = 0.0;
             for &(cx, cy) in &continent_seeds {
                 let dx = (wx - cx) / world_w;
                 let dy = (wy - cy) / world_h;
                 let dist_sq = dx * dx + dy * dy;
-                // Gaussian-ish falloff: strong boost near seeds, fading with distance
-                let radius = 0.15; // ~15% of world size
+                let radius = 0.14;
                 continent_boost += (-dist_sq / (2.0 * radius * radius)).exp();
             }
-            // Normalize: max possible boost is continent_count (all seeds at same point)
             continent_boost = (continent_boost / continent_count as f64).min(1.0);
 
-            // Combine noise + continent bias
-            let e_norm = (e_raw + 1.0) * 0.5; // [0, 1]
-            let elevation = (e_norm * 0.6 + continent_boost * 0.4).clamp(0.0, 1.0);
+            let e_norm = (e_raw + 1.0) * 0.5;
+            let elev = (e_norm * 0.6 + continent_boost * 0.4).clamp(0.0, 1.0);
 
-            // Edge falloff: push map edges toward ocean
+            // Edge falloff: push map borders toward ocean
             let nx = (wx / world_w - 0.5) * 2.0;
             let ny = (wy / world_h - 0.5) * 2.0;
             let edge_dist = 1.0 - (1.0 - nx * nx) * (1.0 - ny * ny);
-            let elevation = (elevation * (1.0 - edge_dist * 0.7)).max(0.0);
+            let elev = (elev * (1.0 - edge_dist * 0.7)).max(0.0);
 
-            // Chokepoint detail: high-frequency noise creates thin land bridges / straits
+            // Chokepoint detail: high-frequency noise carves straits / builds land bridges
             let choke = detail_noise.get([wx * 0.003, wy * 0.003]);
-            // Near the land/water boundary, detail noise can carve straits or extend bridges
-            let elevation = elevation
-                + choke * 0.04 * (1.0 - (elevation - water_threshold).abs().min(0.15) / 0.15);
+            let elev =
+                elev + choke * 0.04 * (1.0 - (elev - water_threshold).abs().min(0.15) / 0.15);
 
-            // Moisture for biome selection within land
+            elevations[row * gw + col] = elev;
+
+            // Moisture for biome variety
             let m = (moisture_noise.get([wx * 0.0012, wy * 0.0012]) + 1.0) * 0.5;
 
-            // Biome assignment
-            let biome = if elevation < water_threshold {
-                Biome::Water
-            } else {
-                // Latitude-driven temperature: 0=polar, 0.5=equator, 1=polar
-                let temp_lat = 1.0 - (lat - 0.5).abs() * 2.0; // 0 at poles, 1 at equator
+            // Latitude-driven temperature: 0 at poles, 1 at equator
+            let temp = 1.0 - (lat - 0.5).abs() * 2.0;
 
-                if temp_lat < 0.2 {
-                    // Near-polar: tundra (rock/barren)
-                    if m > 0.6 { Biome::Forest } else { Biome::Rock }
-                } else if temp_lat < 0.5 {
-                    // Temperate
-                    if m > 0.55 {
-                        Biome::Forest
-                    } else {
-                        Biome::Grass
-                    }
+            // Biome from elevation x temperature x moisture (6+ types)
+            let biome = if elev < water_threshold {
+                Biome::Water
+            } else if temp < 0.15 {
+                // Near-polar: tundra (passable barren)
+                Biome::Tundra
+            } else if temp < 0.3 {
+                // Sub-polar / boreal
+                if m > 0.5 {
+                    Biome::Forest // taiga
                 } else {
-                    // Equatorial / warm
-                    if m > 0.65 {
-                        Biome::Forest
-                    } else {
-                        Biome::Grass
-                    }
+                    Biome::Tundra
+                }
+            } else if temp < 0.6 {
+                // Temperate
+                if m > 0.6 {
+                    Biome::Forest
+                } else if m > 0.3 {
+                    Biome::Grass
+                } else {
+                    Biome::Desert
+                }
+            } else {
+                // Tropical / equatorial
+                if m > 0.55 {
+                    Biome::Jungle
+                } else if m > 0.25 {
+                    Biome::Grass
+                } else {
+                    Biome::Desert
                 }
             };
 
-            let cell = &mut grid.cells[row * grid.width + col];
+            let cell = &mut grid.cells[row * gw + col];
             cell.terrain = biome;
             cell.original_terrain = biome;
+        }
+    }
+
+    // Pass 2: carve rivers -- one per continent seed, flowing downhill to coast
+    carve_rivers(grid, &elevations, &continent_seeds, water_threshold, seed);
+
+    // Pass 3: place volcanoes -- Rock clusters at high-elevation coast-adjacent cells
+    place_volcanoes(grid, &elevations, water_threshold, seed);
+}
+
+/// Carve rivers from high-elevation land toward the coast.
+/// For each continent seed, find the highest non-water cell within its influence radius,
+/// then do a steepest-descent walk to the ocean, marking cells as Water.
+/// Only marks cells that are currently land (not already Water/Rock).
+fn carve_rivers(
+    grid: &mut WorldGrid,
+    elevations: &[f64],
+    continent_seeds: &[(f64, f64)],
+    water_threshold: f64,
+    seed: u64,
+) {
+    use rand::{Rng, SeedableRng};
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(seed.wrapping_add(0xdead_beef));
+
+    let gw = grid.width;
+    let gh = grid.height;
+
+    // For each continent, find a high-elevation source point near the seed
+    for (ci, &(sx, sy)) in continent_seeds.iter().enumerate() {
+        // Search radius in grid cells: ~20% of grid width
+        let search_radius = (gw.min(gh) as f64 * 0.20) as i32;
+        let sc = (sx / grid.cell_size as f64) as i32;
+        let sr = (sy / grid.cell_size as f64) as i32;
+
+        // Find highest land cell within search radius
+        let mut best_elev = water_threshold + 0.05; // must be clearly above water
+        let mut best_col = -1i32;
+        let mut best_row = -1i32;
+
+        for dr in -search_radius..=search_radius {
+            for dc in -search_radius..=search_radius {
+                let col = sc + dc;
+                let row = sr + dr;
+                if col < 0 || row < 0 || col >= gw as i32 || row >= gh as i32 {
+                    continue;
+                }
+                let idx = row as usize * gw + col as usize;
+                let e = elevations[idx];
+                if e > best_elev && !grid.cells[idx].terrain.is_impassable() {
+                    best_elev = e;
+                    best_col = col;
+                    best_row = row;
+                }
+            }
+        }
+
+        if best_col < 0 {
+            continue; // no valid source on this continent
+        }
+
+        // Steepest-descent walk to ocean -- max steps to prevent infinite loops
+        let max_steps = gw + gh;
+        let mut cur_col = best_col as usize;
+        let mut cur_row = best_row as usize;
+
+        for (river_len, _) in (0..max_steps).enumerate() {
+            let idx = cur_row * gw + cur_col;
+
+            // Reached water: done
+            if grid.cells[idx].terrain == Biome::Water {
+                break;
+            }
+
+            // Mark current cell as river (Water)
+            if river_len > 2 && grid.cells[idx].terrain != Biome::Rock {
+                // Keep first 2 cells dry so source isn't immediately ocean
+                grid.cells[idx].terrain = Biome::Water;
+                grid.cells[idx].original_terrain = Biome::Water;
+            }
+
+            // Find the lowest neighbor (steepest descent)
+            let mut best_neighbor_elev = elevations[idx];
+            let mut best_nc = cur_col as i32;
+            let mut best_nr = cur_row as i32;
+
+            // Check 4-directional neighbors (no diagonals for cleaner rivers)
+            let dirs: [(i32, i32); 4] = [(0, -1), (0, 1), (-1, 0), (1, 0)];
+            for (dc, dr) in dirs {
+                let nc = cur_col as i32 + dc;
+                let nr = cur_row as i32 + dr;
+                if nc < 0 || nr < 0 || nc >= gw as i32 || nr >= gh as i32 {
+                    continue;
+                }
+                let ne = elevations[nr as usize * gw + nc as usize];
+                if ne < best_neighbor_elev {
+                    best_neighbor_elev = ne;
+                    best_nc = nc;
+                    best_nr = nr;
+                }
+            }
+
+            if best_nc == cur_col as i32 && best_nr == cur_row as i32 {
+                // Stuck in a depression: add a small random nudge to escape
+                let dirs_shuffle: [(i32, i32); 4] = {
+                    let mut d = [(0i32, -1i32), (0, 1), (-1, 0), (1, 0)];
+                    // Simple Fisher-Yates with rng
+                    for i in (1..4).rev() {
+                        let j = rng.random_range(0..=i);
+                        d.swap(i, j);
+                    }
+                    d
+                };
+                let mut moved = false;
+                for (dc, dr) in dirs_shuffle {
+                    let nc = cur_col as i32 + dc;
+                    let nr = cur_row as i32 + dr;
+                    if nc >= 0 && nr >= 0 && nc < gw as i32 && nr < gh as i32 {
+                        let nidx = nr as usize * gw + nc as usize;
+                        if grid.cells[nidx].terrain != Biome::Rock {
+                            cur_col = nc as usize;
+                            cur_row = nr as usize;
+                            moved = true;
+                            break;
+                        }
+                    }
+                }
+                if !moved {
+                    break; // totally stuck, abandon river
+                }
+            } else {
+                cur_col = best_nc as usize;
+                cur_row = best_nr as usize;
+            }
+        }
+
+        let _ = ci; // suppress unused warning
+    }
+}
+
+/// Place volcano Rock clusters at high-elevation land cells near continent edges.
+/// "Near coast" = land cells adjacent to ocean within ~3 cells of the water boundary.
+/// Volcanic zones get a ring of fertile Rock around their center.
+fn place_volcanoes(grid: &mut WorldGrid, elevations: &[f64], water_threshold: f64, seed: u64) {
+    use rand::{Rng, SeedableRng};
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(seed.wrapping_add(0xcafe_babe));
+
+    let gw = grid.width;
+    let gh = grid.height;
+
+    // Collect candidate cells: high elevation + near coast (within 4 cells of Water)
+    let near_coast_dist = 5i32;
+    let mut candidates: Vec<(usize, usize, f64)> = Vec::new();
+
+    for row in 2..(gh - 2) {
+        for col in 2..(gw - 2) {
+            let idx = row * gw + col;
+            let elev = elevations[idx];
+            if elev < water_threshold + 0.12 {
+                continue; // only high-elevation land
+            }
+            if grid.cells[idx].terrain.is_impassable() {
+                continue;
+            }
+
+            // Check if any cell within near_coast_dist is Water
+            let mut near_water = false;
+            'outer: for dr in -near_coast_dist..=near_coast_dist {
+                for dc in -near_coast_dist..=near_coast_dist {
+                    let nc = col as i32 + dc;
+                    let nr = row as i32 + dr;
+                    if nc < 0 || nr < 0 || nc >= gw as i32 || nr >= gh as i32 {
+                        continue;
+                    }
+                    if grid.cells[nr as usize * gw + nc as usize].terrain == Biome::Water {
+                        near_water = true;
+                        break 'outer;
+                    }
+                }
+            }
+            if near_water {
+                candidates.push((col, row, elev));
+            }
+        }
+    }
+
+    if candidates.is_empty() {
+        return;
+    }
+
+    // Sort by elevation descending -- volcanoes prefer the highest coastal peaks
+    candidates.sort_by(|a, b| b.2.partial_cmp(&a.2).unwrap_or(std::cmp::Ordering::Equal));
+
+    // Place volcanoes with minimum spacing (15 grid cells apart)
+    let min_volcano_spacing = 15i32;
+    let max_volcanoes = (gw * gh / 5000).clamp(2, 8);
+    let mut placed: Vec<(i32, i32)> = Vec::new();
+
+    for &(vc, vr, _) in &candidates {
+        if placed.len() >= max_volcanoes {
+            break;
+        }
+        let too_close = placed.iter().any(|&(pc, pr)| {
+            let dc = vc as i32 - pc;
+            let dr = vr as i32 - pr;
+            dc * dc + dr * dr < min_volcano_spacing * min_volcano_spacing
+        });
+        if too_close {
+            continue;
+        }
+
+        // Skip if randomly rejected (only ~60% of candidates become volcanoes)
+        if rng.random_range(0..10) < 4 {
+            continue;
+        }
+
+        placed.push((vc as i32, vr as i32));
+
+        // Stamp a small Rock cluster (volcano cone): radius 1 core, radius 3 ring
+        let cone_radius = 1i32;
+        let ring_radius = 3i32;
+
+        for dr in -ring_radius..=ring_radius {
+            for dc in -ring_radius..=ring_radius {
+                let nc = vc as i32 + dc;
+                let nr = vr as i32 + dr;
+                if nc < 0 || nr < 0 || nc >= gw as i32 || nr >= gh as i32 {
+                    continue;
+                }
+                let dist_sq = dc * dc + dr * dr;
+                let cell = &mut grid.cells[nr as usize * gw + nc as usize];
+                if cell.terrain == Biome::Water {
+                    continue; // never overwrite ocean
+                }
+                if dist_sq <= cone_radius * cone_radius {
+                    // Rock cone at center
+                    cell.terrain = Biome::Rock;
+                    cell.original_terrain = Biome::Rock;
+                } else {
+                    // Fertile ring: Grass (rich volcanic soil)
+                    if cell.terrain != Biome::Rock {
+                        cell.terrain = Biome::Grass;
+                        cell.original_terrain = Biome::Grass;
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #240

## Summary

- **3 new Biome variants**: `Desert`, `Tundra`, `Jungle` -- raises natural biome count from 4 to 7 (satisfies >= 6 requirement)
- **Random 3-10 continent seeds** per world, placed with separation constraint (>25% world width apart)
- **Latitude x moisture biome table**: tundra (polar) -> boreal forest -> temperate (grass/forest/desert) -> tropical (jungle/grass/desert)
- **River generation**: steepest-descent walk from highest-elevation point near each continent seed, carves Water path to coast
- **Volcano placement**: Rock cluster at high-elevation coastal cells with fertile Grass ring, max 8 volcanoes per map, spaced >= 15 cells apart
- **Jungle gets forest cover miss chance** (25%, same as Forest) in combat
- `is_impassable()` helper on Biome -- replaces scattered `matches!(t, Water | Rock)` checks

## Acceptance criteria

- [x] World gen produces 3-10 distinct continents separated by ocean
- [x] Climate zones vary by latitude (polar/Tundra, temperate Grass/Forest/Desert, tropical Jungle)
- [x] At least 6 biome types assigned based on temperature + moisture
- [x] Biome transitions are smooth (continuous noise thresholds, no hard jump zones)
- [x] Each continent has at least one river flowing from high ground to coast
- [x] Volcanoes placed at continent edges / tectonic boundaries
- [x] Natural chokepoints exist between continents (retained detail noise for straits/bridges)
- [ ] World feels geographically coherent when viewed at full zoom-out -- **needs local in-game verification** (k3s has no display)

## Tests

- `worldmap_has_six_plus_biome_types`: >= 6 distinct biome discriminants
- `worldmap_is_deterministic_for_same_seed`: identical output for same seed
- `worldmap_rivers_carve_water_inland`: > 5% water in mid-grid (rivers + ocean)
- `worldmap_volcanoes_place_rock_in_temperate_zone`: Rock cells in non-ice-cap zone
- `new_biome_passability_contract`: Desert/Tundra/Jungle passable, Water/Rock impassable
- `new_biome_pathfind_costs`: correct A* cost values

370 tests pass, clippy clean.

## Open

- Visual coherence at full zoom-out needs local BRP in-game profiling -- k3s cannot run the game
- Jungle and Forest render identically (both = dark grass tileset index 1); visual distinction requires new tileset tiles beyond current 11-tile atlas